### PR TITLE
BSD.pm bugfixes

### DIFF
--- a/lib/Software/License/BSD.pm
+++ b/lib/Software/License/BSD.pm
@@ -5,7 +5,7 @@ use base 'Software::License';
 # ABSTRACT: The (three-clause) BSD License
 
 sub name { 'The (three-clause) BSD License' }
-sub url  { 'http://www.opensource.org/licenses/bsd-license.php' }
+sub url  { 'http://opensource.org/licenses/BSD-3-Clause' }
 sub meta_name  { 'bsd' }
 sub meta2_name { 'bsd' }
 

--- a/t/bsd-url.t
+++ b/t/bsd-url.t
@@ -8,7 +8,7 @@ use Software::License::Mozilla_1_0;
 
 # TEST
 is (scalar(Software::License::BSD->url()),
-    'http://www.opensource.org/licenses/bsd-license.php',
+    'http://opensource.org/licenses/BSD-3-Clause',
     "BSD->url() is OK."
 );
 


### PR DESCRIPTION
There are a couple of minor bugs in Software::License::BSD.pm:
- The text of the license contains a reference to REGENTS rather than COPYRIGHT HOLDER
- The URL points to a page that describes the 2-Clause BSD rather than the 3-Clause license that the module actually represents
