### PR TITLE
Add generic BSD 2-Clause license, not hard-coded to FreeBSD Project

### DIFF
--- a/lib/Software/License.pm
+++ b/lib/Software/License.pm
@@ -174,6 +174,7 @@ The specific license:
 * L<Software::License::Artistic_1_0>
 * L<Software::License::Artistic_2_0>
 * L<Software::License::BSD>
+* L<Software::License::BSD_2_Clause>
 * L<Software::License::CC0>
 * L<Software::License::FreeBSD>
 * L<Software::License::GFDL_1_2>

--- a/lib/Software/License/BSD_2_Clause.pm
+++ b/lib/Software/License/BSD_2_Clause.pm
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+package Software::License::BSD_2_Clause;
+use base 'Software::License';
+# ABSTRACT: The (two-clause) BSD License
+
+sub name { 'The BSD 2-Clause License' }
+sub url  { 'http://opensource.org/licenses/BSD-2-Clause' }
+sub meta_name  { 'bsd_2_clause' }
+sub meta2_name { 'bsd_2_clause' }
+
+1;
+__DATA__
+__LICENSE__
+The BSD 2-Clause License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/lib/Software/LicenseUtils.pm
+++ b/lib/Software/LicenseUtils.pm
@@ -27,6 +27,7 @@ my @phrases = (
   },
   'GNU (?:lesser|library) (?:general )?public license'  => [ qw(LGPL_2_1 LGPL_3_0) ],
   'BSD license'                => 'BSD',
+  'BSD 2 Clause license'       => 'BSD_2_Clause',
   "Artistic license $_v?(\\d)" => sub { "Artistic_$_[0]_0" },
   'Artistic license'           => [ map { "Artistic_$_\_0" } (1..2) ],
   "LGPL,? $_v?(\\d)"             => sub {


### PR DESCRIPTION
The Software::License::FreeBSD.pm module refers to the 2-Clause BSD license, but it hard-codes the FreeBSD Project as owner of the code covered by the license.

This pull request adds a module for a generic 2-Clause BSD license. I assume the existing FreeBSD.pm module shouldn't be changed in case existing users depend on the current, hard-coded language.
