### PR TITLE
look for the header before the license body

### DIFF
--- a/lib/Software/LicenseUtils.pm
+++ b/lib/Software/LicenseUtils.pm
@@ -43,19 +43,26 @@ my @phrases = (
 sub guess_license_from_pod {
   my ($class, $pm_text) = @_;
   die "can't call guess_license_* in scalar context" unless wantarray;
+  return unless $pm_text =~ /
+    (
+      =head \d \s+
+      (?:licen[cs]e|licensing|copyright|legal)\b
+    )
+  /ixmsg;
+
+  my $header = $1;
 
 	if (
 		$pm_text =~ m/
+      \G
       (
-        =head \d \s+
-        (?:licen[cs]e|licensing|copyright|legal)\b
         .*?
       )
       (=head\\d.*|=cut.*|)
       \z
     /ixms
   ) {
-		my $license_text = $1;
+		my $license_text = "$header$1";
 
     for (my $i = 0; $i < @phrases; $i += 2) {
       my ($pattern, $license) = @phrases[ $i .. $i+1 ];


### PR DESCRIPTION
Hi. I found Software::LicenseUtils::guess_license_from_pod() may take minutes to guess licenses of some huge modules. This actually may be an issue of perl's regex engine, but anyway, this commit makes guessing reasonably fast.

The following script should reproduce the issue for you:

``` perl
use strict;
use warnings;
use lib "lib";
use Test::More;
use Software::LicenseUtils;
use File::Slurp qw/slurp/;

diag "downloading HTML::Dojo";
system(qw/cpanm -L extlib -n HTML::Dojo/);

diag "slurping pod";
my $pod = slurp("extlib/lib/perl5/HTML/Dojo/src.pm");

diag "start guessing";
my @licenses;
eval {
  local $SIG{ALRM} = sub { die "alarm\n" };
  alarm 30;
  @licenses = Software::LicenseUtils->guess_license_from_pod($pod);
  alarm 0;
};

ok !$@, "no timeout";
diag $@ if $@;
diag explain \@licenses;

done_testing;

```
