### PR TITLE
Strip tailing dots from copyright holder when used at end of sentence

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Software-License
 
 {{$NEXT}}
+          copyright holder names ending with a period (like "FooBar, Inc.")
+          no longer produce sentences ending in two dots (..). (Dave Rolsky)
 
 0.103005  2012-12-08 16:15:30 America/New_York
           add MPL 2.0 (thanks, Bernhard Amann)

--- a/lib/Software/License.pm
+++ b/lib/Software/License.pm
@@ -139,6 +139,17 @@ sub meta2_name {
   return undef;
 }
 
+{
+  package
+    Software::License::_Fill;
+
+  sub strip_trailing_dot {
+    my $str = shift;
+    $str =~ s/\.$//;
+    return $str;
+  }
+}
+
 sub _fill_in {
   my ($self, $which) = @_;
 
@@ -149,6 +160,7 @@ sub _fill_in {
     $$template,
     HASH => { self => \$self },
     DELIMITERS => [ qw({{ }}) ],
+    PACKAGE => 'Software::License::_Fill',
   );
 }
 
@@ -200,7 +212,7 @@ The specific license:
 
 __DATA__
 __NOTICE__
-This software is Copyright (c) {{$self->year}} by {{$self->holder}}.
+This software is Copyright (c) {{$self->year}} by {{strip_trailing_dot($self->holder)}}.
 
 This is free software, licensed under:
 

--- a/lib/Software/License/Custom.pm
+++ b/lib/Software/License/Custom.pm
@@ -51,7 +51,7 @@ the end of the file. Example:
    foo_bar_meta2
    __[ NOTICE ]__
    Copyright (C) 2000-2002 by P.R. Evious
-   Copyright (C) {{$self->year}} by {{$self->holder}}.
+   Copyright (C) {{$self->year}} by {{strip_trailing_dot($self->holder)}}.
 
    This is free software, licensed under {{$self->name}}.
 
@@ -159,6 +159,17 @@ on the class.  This may become fatal in the future.
 * notice
 * fulltext
 * version
+
+=head1 TEMPLATE SUBROUTINES
+
+Inside the templates that your license class provides, you can call the
+C<strip_trailing_dot()> subroutine. This is useful when you need to insert the
+copyright holder name at the end of the sentence:
+
+  This software is Copyright (c) {{$self->year}} by {{strip_trailing_dot($self->holder)}}.
+
+That way if the holder value is something like "FooBar, Inc.", you don't end
+the sentence with two dots.
 
 =cut
 

--- a/lib/Software/License/GFDL_1_2.pm
+++ b/lib/Software/License/GFDL_1_2.pm
@@ -12,7 +12,7 @@ sub meta2_name { 'gfdl_1_2' }
 1;
 __DATA__
 __NOTICE__
- Copyright (c)  {{$self->year}}  {{$self->holder}}.
+ Copyright (c)  {{$self->year}}  {{strip_trailing_dot($self->holder)}}.
   Permission is granted to copy, distribute and/or modify this document
   under the terms of the GNU Free Documentation License, Version 1.2
   or any later version published by the Free Software Foundation;

--- a/lib/Software/License/GFDL_1_3.pm
+++ b/lib/Software/License/GFDL_1_3.pm
@@ -12,7 +12,7 @@ sub meta2_name { 'gfdl_1_3' }
 1;
 __DATA__
 __NOTICE__
- Copyright (C)  {{$self->year}}  {{$self->holder}}.
+ Copyright (C)  {{$self->year}}  {{strip_trailing_dot($self->holder)}}.
   Permission is granted to copy, distribute and/or modify this document
   under the terms of the GNU Free Documentation License, Version 1.3
   or any later version published by the Free Software Foundation;

--- a/lib/Software/License/None.pm
+++ b/lib/Software/License/None.pm
@@ -13,7 +13,7 @@ sub meta2_name { 'restricted'  }
 1;
 __DATA__
 __NOTICE__
-This software is copyright (c) {{$self->year}} by {{$self->holder}}.  No
+This software is copyright (c) {{$self->year}} by {{strip_trailing_dot($self->holder)}}.  No
 license is granted to other entities.
 __LICENSE__
 All rights reserved.

--- a/lib/Software/License/Perl_5.pm
+++ b/lib/Software/License/Perl_5.pm
@@ -31,7 +31,7 @@ sub _tal {
 1;
 __DATA__
 __NOTICE__
-This software is copyright (c) {{$self->year}} by {{$self->holder}}.
+This software is copyright (c) {{$self->year}} by {{strip_trailing_dot($self->holder)}}.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/t/custom-license
+++ b/t/custom-license
@@ -7,7 +7,7 @@ foo_bar_meta
 __{ META2_NAME }__
 foo_bar_meta2
 __[ NOTICE ]__
-Copyright (C) {{$self->year}} by {{$self->holder}}.
+Copyright (C) {{$self->year}} by {{strip_trailing_dot($self->holder)}}.
 
 This is free software, licensed under {{$self->name}}.
 

--- a/t/custom.t
+++ b/t/custom.t
@@ -41,4 +41,16 @@ Well... this is only some sample text. I'm true... only sample text!!!
 Yes, spanning more lines and more paragraphs.
 END_OF_FULLTEXT
 
+$slc = Software::License::Custom->new({
+   holder => 'FooBar, Inc.',
+   year   => 1972,
+   filename => 't/custom-license'
+});
+
+is($slc->notice, <<'END_OF_NOTICE', 'strip_trailing_dot($self->holder)');
+Copyright (C) 1972 by FooBar, Inc.
+
+This is free software, licensed under The Foo-Bar License.
+END_OF_NOTICE
+
 done_testing;


### PR DESCRIPTION
Yes, I'm crazy pedantic. I can't believe I even bothered patching this. But I did.
