### PR TITLE
Inserted blank after package name.

### DIFF
--- a/lib/Software/License/AGPL_3.pm
+++ b/lib/Software/License/AGPL_3.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::AGPL_3;
+
 use parent 'Software::License';
 # ABSTRACT: GNU Affero General Public License, Version 3
 

--- a/lib/Software/License/Apache_1_1.pm
+++ b/lib/Software/License/Apache_1_1.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::Apache_1_1;
+
 use parent 'Software::License';
 # ABSTRACT: The Apache Software License, Version 1.1
 

--- a/lib/Software/License/Apache_2_0.pm
+++ b/lib/Software/License/Apache_2_0.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::Apache_2_0;
+
 use parent 'Software::License';
 # ABSTRACT: The Apache License, Version 2.0
 

--- a/lib/Software/License/Artistic_1_0.pm
+++ b/lib/Software/License/Artistic_1_0.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::Artistic_1_0;
+
 use parent 'Software::License';
 # ABSTRACT: The Artistic License
 

--- a/lib/Software/License/Artistic_2_0.pm
+++ b/lib/Software/License/Artistic_2_0.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::Artistic_2_0;
+
 use parent 'Software::License';
 # ABSTRACT: The Artistic License 2.0
 

--- a/lib/Software/License/BSD.pm
+++ b/lib/Software/License/BSD.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::BSD;
+
 use parent 'Software::License';
 # ABSTRACT: The (three-clause) BSD License
 

--- a/lib/Software/License/CC0_1_0.pm
+++ b/lib/Software/License/CC0_1_0.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::CC0_1_0;
+
 use parent 'Software::License';
 # ABSTRACT: the "public domain"-like CC0 license, version 1.0
 

--- a/lib/Software/License/FreeBSD.pm
+++ b/lib/Software/License/FreeBSD.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::FreeBSD;
+
 use parent 'Software::License';
 # ABSTRACT: The FreeBSD License (aka two-clause BSD)
 

--- a/lib/Software/License/GFDL_1_2.pm
+++ b/lib/Software/License/GFDL_1_2.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::GFDL_1_2;
+
 use parent 'Software::License';
 # ABSTRACT: The GNU Free Documentation License v1.2
 

--- a/lib/Software/License/GFDL_1_3.pm
+++ b/lib/Software/License/GFDL_1_3.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::GFDL_1_3;
+
 use parent 'Software::License';
 # ABSTRACT: The GNU Free Documentation License v1.3
 

--- a/lib/Software/License/GPL_1.pm
+++ b/lib/Software/License/GPL_1.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::GPL_1;
+
 use parent 'Software::License';
 # ABSTRACT: GNU General Public License, Version 1
 

--- a/lib/Software/License/GPL_2.pm
+++ b/lib/Software/License/GPL_2.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::GPL_2;
+
 use parent 'Software::License';
 # ABSTRACT: GNU General Public License, Version 2
 

--- a/lib/Software/License/GPL_3.pm
+++ b/lib/Software/License/GPL_3.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::GPL_3;
+
 use parent 'Software::License';
 # ABSTRACT: GNU General Public License, Version 3
 

--- a/lib/Software/License/LGPL_2_1.pm
+++ b/lib/Software/License/LGPL_2_1.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::LGPL_2_1;
+
 use parent 'Software::License';
 # ABSTRACT: GNU Lesser General Public License, Version 2.1
 

--- a/lib/Software/License/LGPL_3_0.pm
+++ b/lib/Software/License/LGPL_3_0.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::LGPL_3_0;
+
 use parent 'Software::License';
 # ABSTRACT: GNU Lesser General Public License, Version 3
 

--- a/lib/Software/License/MIT.pm
+++ b/lib/Software/License/MIT.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::MIT;
+
 use parent 'Software::License';
 # ABSTRACT: The MIT (aka X11) License
 

--- a/lib/Software/License/Mozilla_1_0.pm
+++ b/lib/Software/License/Mozilla_1_0.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::Mozilla_1_0;
+
 use parent 'Software::License';
 # ABSTRACT: Mozilla Public License 1.0
 

--- a/lib/Software/License/Mozilla_1_1.pm
+++ b/lib/Software/License/Mozilla_1_1.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::Mozilla_1_1;
+
 use parent 'Software::License';
 # ABSTRACT: The Mozilla Public License 1.1
 

--- a/lib/Software/License/Mozilla_2_0.pm
+++ b/lib/Software/License/Mozilla_2_0.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::Mozilla_2_0;
+
 use parent 'Software::License';
 # ABSTRACT: Mozilla Public License Version 2.0
 

--- a/lib/Software/License/None.pm
+++ b/lib/Software/License/None.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::None;
+
 use parent 'Software::License';
 # ABSTRACT: describes a "license" that gives no license for re-use
 

--- a/lib/Software/License/OpenSSL.pm
+++ b/lib/Software/License/OpenSSL.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::OpenSSL;
+
 use parent 'Software::License';
 # ABSTRACT: The OpenSSL License
 

--- a/lib/Software/License/Perl_5.pm
+++ b/lib/Software/License/Perl_5.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::Perl_5;
+
 use parent 'Software::License';
 # ABSTRACT: The Perl 5 License (Artistic 1 & GPL 1)
 

--- a/lib/Software/License/PostgreSQL.pm
+++ b/lib/Software/License/PostgreSQL.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::PostgreSQL;
+
 use parent 'Software::License';
 # ABSTRACT: The PostgreSQL License
 

--- a/lib/Software/License/QPL_1_0.pm
+++ b/lib/Software/License/QPL_1_0.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::QPL_1_0;
+
 use parent 'Software::License';
 # ABSTRACT: The Q Public License, Version 1.0
 

--- a/lib/Software/License/SSLeay.pm
+++ b/lib/Software/License/SSLeay.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::SSLeay;
+
 use parent 'Software::License';
 # ABSTRACT: The Original SSLeay License
 

--- a/lib/Software/License/Sun.pm
+++ b/lib/Software/License/Sun.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::Sun;
+
 use parent 'Software::License';
 # ABSTRACT: Sun Internet Standards Source License (SISSL)
 

--- a/lib/Software/License/Zlib.pm
+++ b/lib/Software/License/Zlib.pm
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 package Software::License::Zlib;
+
 use parent 'Software::License';
 # ABSTRACT: The zlib License
 


### PR DESCRIPTION
Dist::Zilla::Plugin::PkgVersion requires the blank after packgae name
for insertion version number.
