### PR TITLE
Fix license class names of GPL

### DIFF
--- a/lib/Software/LicenseUtils.pm
+++ b/lib/Software/LicenseUtils.pm
@@ -39,8 +39,8 @@ my @phrases = (
     $_[0] == 2 ? 'LGPL_2_1' : $_[0] == 3 ? 'LGPL_3_0' : ()
   },
   'LGPL'                       => [ qw(LGPL_2_1 LGPL_3_0) ],
-  "GPL,? $_v?(\\d)"              => sub { "GPL_$_[0]_0" },
-  'GPL'                        => [ map { "GPL_$_\_0" } (1..3) ],
+  "GPL,? $_v?(\\d)"              => sub { "GPL_$_[0]" },
+  'GPL'                        => [ map { "GPL_$_" } (1..3) ],
   'BSD'                        => 'BSD',
   'Artistic'                   => [ map { "Artistic_$_\_0" } (1..2) ],
   'MIT'                        => 'MIT',


### PR DESCRIPTION
In original code, `guess_license_from_pod` returns `Software::License::GPL_1_0`,
or `Software::License::GPL_2_0` or `Software::License::GPL_3_0` for `GPL` license.
But there are no such classes. `_0` is not necessary.

Please see this patch.
