### PR TITLE
Add method guess license from meta json

### DIFF
--- a/lib/Software/LicenseUtils.pm
+++ b/lib/Software/LicenseUtils.pm
@@ -138,11 +138,9 @@ sub guess_license_from_meta {
   my ($class, $meta_text) = @_;
   die "can't call guess_license_* in scalar context" unless wantarray;
 
-  my ($license_text) = $meta_text =~ m{\b["']?license["']?\s*:\s*["']?([a-z_0-9]+)["']?}gm;
+  my ($license_text) = $meta_text =~ m{\b["']?license["']?\s*:\s*\[?\s*["']?([a-z_0-9]+)["']?}gm or return;
 
-  return unless $license_text and my $license = $meta_keys{ $license_text };
-
-  return map { "Software::License::$_" } sort keys %$license;
+  return map { "Software::License::$_" } sort keys %{$meta_keys{$license_text}};
 }
 
 {

--- a/lib/Software/LicenseUtils.pm
+++ b/lib/Software/LicenseUtils.pm
@@ -8,6 +8,7 @@ package Software::LicenseUtils;
 use File::Spec;
 use IO::Dir;
 use Module::Load;
+use JSON::PP;
 
 =method guess_license_from_pod
 
@@ -147,6 +148,37 @@ sub guess_license_from_meta {
   no warnings 'once';
   *guess_license_from_meta_yml = \&guess_license_from_meta;
 }
+
+=method guess_license_from_meta_json
+
+  my $guesses = Software::LicenseUtils->guess_license_from_meta_json($meta_json);
+
+Given the content of the META.json file found in a CPAN distribution, this
+method makes a guess as to which licenses may apply to the distribution.
+
+It will return a hash reference that contains keys of licenses name and
+values of Software::License classes.
+
+CPAN Meta spec 2.0 allows that the distribution has multiple licenses.
+guess_license_from_meta_json will return a guess to each specified licenses
+in a hash reference format.
+
+=cut
+
+sub guess_license_from_meta_json {
+  my ($class, $meta_json) = @_;
+
+  my $meta = decode_json($meta_json);
+  my @licenses = @{ $meta->{license} } or return;
+
+  my $guesses = {};
+  for my $license ( @licenses ) {
+    $guesses->{$license} = [ Software::LicenseUtils->guess_license_from_meta_key($license, 2) ];
+  }
+
+  return $guesses; 
+}
+
 
 =method guess_license_from_meta_key
 

--- a/t/utils.t
+++ b/t/utils.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 6;
+use Test::More tests => 8;
 use Software::LicenseUtils;
 
 {
@@ -149,6 +149,7 @@ END_YAML
    },
    "name" : "Software-License",
    "version" : "0.103010"
+}
 END_JSON
 
   my @guesses = Software::LicenseUtils->guess_license_from_meta(
@@ -160,6 +161,13 @@ END_JSON
     [ 'Software::License::Perl_5' ],
     "guessed okay"
   );
+
+  is_deeply(
+    Software::LicenseUtils->guess_license_from_meta_json($fake_json),
+    { perl_5 => [ 'Software::License::Perl_5' ] },
+    "guessed okay from META.json",
+  );
+  
 }
 
 {
@@ -180,6 +188,7 @@ END_JSON
    },
    "name" : "Software-License",
    "version" : "0.103010"
+}
 END_JSON
 
   my @guesses = Software::LicenseUtils->guess_license_from_meta(
@@ -191,5 +200,15 @@ END_JSON
     [ 'Software::License::Perl_5' ],
     "guessed okay from multiple licenses are specified"
   );
+
+  is_deeply(
+    Software::LicenseUtils->guess_license_from_meta_json($fake_json),
+    {
+      perl_5 => [ 'Software::License::Perl_5' ],
+      gpl_1  => [ 'Software::License::GPL_1'  ],
+    },
+    "guessed multiple okay from META.json",
+  );
+
 }
 

--- a/t/utils.t
+++ b/t/utils.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 5;
+use Test::More tests => 6;
 use Software::LicenseUtils;
 
 {
@@ -134,50 +134,21 @@ END_YAML
 {
   my $fake_json = <<'END_JSON';
 {
-   "resources" : {
-      "repository" : "http://github.com/rjbs/dist-zilla"
-   },
-   "generated_by" : "Dist::Zilla::Plugin::MetaJSON version 1.091370",
-   "version" : "1.091370",
-   "name" : "Dist-Zilla",
-   "requires" : {
-      "DateTime" : "0.44",
-      "Config::INI::MVP::Reader" : "0.018",
-      "Pod::Eventual" : "0",
-      "App::Cmd" : "0.200",
-      "String::RewritePrefix" : "0.002",
-      "Data::Section" : "0.004",
-      "File::chdir" : "0",
-      "YAML::XS" : "0",
-      "String::Formatter" : "0",
-      "Perl::Version" : "0",
-      "autobox" : "2.53",
-      "Software::License" : "0",
-      "Archive::Tar" : "0",
-      "MooseX::ClassAttribute" : "0",
-      "List::MoreUtils" : "0",
-      "Moose" : "0.65",
-      "ExtUtils::Manifest" : "1.54",
-      "String::Flogger" : "1",
-      "File::Find::Rule" : "0",
-      "Mixin::ExtraFields::Param" : "0",
-      "File::HomeDir" : "0",
-      "ExtUtils::MakeMaker" : "0",
-      "CPAN::Uploader" : "0",
-      "Moose::Autobox" : "0.09",
-      "Test::More" : "0",
-      "MooseX::Types::Path::Class" : "0",
-      "Hash::Merge::Simple" : "0",
-      "File::Temp" : "0",
-      "Path::Class" : "0",
-      "Text::Template" : "0"
-   },
-   "abstract" : "distribution builder; installer not included!",
+   "abstract" : "packages that provide templated software licenses",
    "author" : [
-      "Ricardo SIGNES <rjbs@cpan.org>"
+      "Ricardo Signes <rjbs@cpan.org>"
    ],
-   "license" : "perl"
-}
+   "dynamic_config" : 0,
+   "generated_by" : "Dist::Zilla version 5.014, CPAN::Meta::Converter version 2.140640",
+   "license" : [
+      "perl_5"
+   ],
+   "meta-spec" : {
+      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "version" : "2"
+   },
+   "name" : "Software-License",
+   "version" : "0.103010"
 END_JSON
 
   my @guesses = Software::LicenseUtils->guess_license_from_meta(
@@ -188,6 +159,37 @@ END_JSON
     \@guesses,
     [ 'Software::License::Perl_5' ],
     "guessed okay"
+  );
+}
+
+{
+  my $fake_json = <<'END_JSON';
+{
+   "abstract" : "packages that provide templated software licenses",
+   "author" : [
+      "Ricardo Signes <rjbs@cpan.org>"
+   ],
+   "dynamic_config" : 0,
+   "generated_by" : "Dist::Zilla version 5.014, CPAN::Meta::Converter version 2.140640",
+   "license" : [
+      "perl_5", "gpl_1"
+   ],
+   "meta-spec" : {
+      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "version" : "2"
+   },
+   "name" : "Software-License",
+   "version" : "0.103010"
+END_JSON
+
+  my @guesses = Software::LicenseUtils->guess_license_from_meta(
+    $fake_json
+  );
+
+  is_deeply(
+    \@guesses,
+    [ 'Software::License::Perl_5' ],
+    "guessed okay from multiple licenses are specified"
   );
 }
 


### PR DESCRIPTION
I think that the method corresponding to it is required for it since CPAN Meta spec 2 can specify two or more licenses.

I wrote method guess_license_from_meta_json.
