### PR TITLE
Use Module::Runtime instead of Module::Load

### DIFF
--- a/lib/Software/LicenseUtils.pm
+++ b/lib/Software/LicenseUtils.pm
@@ -7,7 +7,7 @@ package Software::LicenseUtils;
 
 use File::Spec;
 use IO::Dir;
-use Module::Load;
+use Module::Runtime ();
 
 =method guess_license_from_pod
 
@@ -67,7 +67,7 @@ for my $lib (map { "$_/Software/License" } @INC) {
     eval {
       (my $mod = $file) =~ s{\.pm$}{};
       my $class = "Software::License::$mod";
-      load $class;
+      Module::Runtime::require_module $class;
       $meta_keys{  $class->meta_name  }{$mod} = undef;
       $meta1_keys{ $class->meta_name  }{$mod} = undef;
       $meta_keys{  $class->meta2_name }{$mod} = undef;


### PR DESCRIPTION
We just want to load a class from its package name. We don't need Module::Load's magic (the same function can load either files or packages). Also, Module::Runtime has workarounds for core perl bugs.
