### PR TITLE
Enable "v" as a version word

### DIFF
--- a/lib/Software/LicenseUtils.pm
+++ b/lib/Software/LicenseUtils.pm
@@ -21,7 +21,7 @@ Calling this method in scalar context is a fatal error.
 
 =cut
 
-my $_v = qr/(?:v(?:er(?:sion|\.))(?: |\.)?)/i;
+my $_v = qr/(?:v(?:er(?:sion|\.))?(?: |\.)?)/i;
 my @phrases = (
   "under the same (?:terms|license) as perl $_v?6" => [],
   'under the same (?:terms|license) as (?:the )?perl'    => 'Perl_5',

--- a/t/utils.t
+++ b/t/utils.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 5;
+use Test::More tests => 6;
 use Software::LicenseUtils;
 
 {
@@ -49,6 +49,31 @@ END_PM
   is_deeply(
     \@guesses,
     [ 'Software::License::Apache_2_0' ],
+    "guessed okay"
+  );
+}
+
+{
+  my $fake_pm = <<'END_PM';
+
+"magic true value";
+__END__
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is Copyright (c) 2015.
+
+This program is released under the following license: GPL v3
+
+=cut
+
+END_PM
+
+  my @guesses = Software::LicenseUtils->guess_license_from_pod($fake_pm);
+
+  is_deeply(
+    \@guesses,
+    [ 'Software::License::GPL_3' ],
     "guessed okay"
   );
 }


### PR DESCRIPTION
...alongside with "version" and "ver.".
Now "GPL v3" isn't parsed as GPLv1 which is important.
