### PR TITLE
program and Program attributes (constructor arguments and

### DIFF
--- a/lib/Software/License.pm
+++ b/lib/Software/License.pm
@@ -22,8 +22,19 @@ use Text::Template ();
 This method returns a new license object for the given license class.  Valid
 arguments are:
 
-  holder - the holder of the copyright; required
-  year   - the year of copyright; defaults to current year
+=for :list
+= holder  
+the holder of the copyright; required
+= year    
+the year of copyright; defaults to current year
+= program 
+the name of software for use in the middle of a sentence
+= Program 
+the name of software for use in the beginning of a sentence
+
+C<program> and C<Program> arguments may be specified both, either one or none. Each argument, if 
+not specified, is defaulted to another one, or to properly capitalized "this program", if both 
+arguments are omitted.
 
 =cut
 
@@ -45,6 +56,29 @@ These methods are attribute readers.
 
 sub year   { defined $_[0]->{year} ? $_[0]->{year} : (localtime)[5]+1900 }
 sub holder { $_[0]->{holder}     }
+
+=method program
+
+Name of software for using in the middle of a sentence.
+
+The method returns value of C<program> constructor argument (if it evaluates as true, i. e.
+defined, non-empty, non-zero), or value of C<Program> constructor argument (if it is true), or
+"this program" as the last resort.
+
+=cut
+
+sub program { $_[0]->{program} || $_[0]->{Program} || 'this program' }
+
+=method Program
+
+Name of software for using in the middle of a sentence.
+
+The method returns value of C<Program> constructor argument (if it is true), or value of C<program>
+constructor argument (if it is true), or "This program" as the last resort.
+
+=cut
+
+sub Program { $_[0]->{Program} || $_[0]->{program} || 'This program' }
 
 sub _dotless_holder {
     my $holder = $_[0]->holder;

--- a/t/program.t
+++ b/t/program.t
@@ -1,0 +1,33 @@
+#!perl
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+
+my $class = 'Software::License::Perl_5';
+require_ok($class);
+
+subtest 'Default' => sub {
+    plan tests => 2;
+    my $lic = $class->new({ holder => 'X. Ample' });
+    is($lic->program, 'this program', 'program');
+    is($lic->Program, 'This program', 'Program');
+};
+
+subtest 'program only' => sub {
+    my $lic = $class->new({ holder => 'X. Ample', program => 'assa' });
+    is($lic->program, 'assa', 'program');
+    is($lic->Program, 'assa', 'Program ');
+};
+
+subtest 'Program only' => sub {
+    my $lic = $class->new({ holder => 'X. Ample', Program => 'Assa' });
+    is($lic->program, 'Assa', 'program ');
+    is($lic->Program, 'Assa', 'Program');
+};
+
+subtest 'both program and Program' => sub {
+    my $lic = $class->new({ holder => 'X. Ample', program => 'assa', Program => 'Assa' });
+    is($lic->program, 'assa', 'program');
+    is($lic->Program, 'Assa', 'Program ');
+};


### PR DESCRIPTION
accessors) introduced; test written.

These attributes may be used in license notice text instead of "this program" and "this software", e. g.:

```
__NOTICE__
{{$self->Program}} is Copyright (c) {{$self->year}} by {{$self->_dotless_holder}}.

This is free software, licensed under:

  {{ $self->name }}
```

instead of current

```
__NOTICE__
This software is Copyright (c) {{$self->year}} by {{$self->_dotless_holder}}.

This is free software, licensed under:

  {{ $self->name }}
```

[Proposed fix for Dist::Zilla](https://github.com/rjbs/Dist-Zilla/pull/486) passes program name from `dist.ini` to `Software::License` constructor.
