### PR TITLE
new_from_short_name falls back on Software::License::ShortName class

### DIFF
--- a/t/short_name.t
+++ b/t/short_name.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 6;
+use Test::More tests => 8;
 
 my $class = 'Software::LicenseUtils';
 require_ok($class);
@@ -17,3 +17,16 @@ is($license->year, (localtime)[5]+1900, '(c) year');
 isa_ok($license,'Software::License::GPL_1',"license class");
 like($license->name, qr/version 1/i, "license name");
 like($license->fulltext, qr/general public/i, 'license text');
+
+# test fall back
+my $mit_lic = $class->new_from_short_name({
+    short_name => 'MIT',
+    holder => 'X. Ample'
+});
+isa_ok($mit_lic,'Software::License::MIT',"license class");
+
+my $apache_lic = $class->new_from_short_name({
+    short_name => 'Apache-2.0',
+    holder => 'X. Ample'
+});
+isa_ok($apache_lic,'Software::License::Apache_2_0',"license class");


### PR DESCRIPTION
Hello

This is a squashed version of the previous PR #31 .

Previously,new_from_short_name worked using a set of pre-defined short names like GPL-1...

Unfortunately, this means that this method failed when using a short name like MIT.

This patch fixes this behavior: when the passed short name is not known (say Foo), new_from_short_name tries to load a class like Software::License::Foo.

I believe that this behavior makes more sense.

All the best
