### PR TITLE
SEE ALSO: link to App::Software::License

### DIFF
--- a/lib/Software/License.pm
+++ b/lib/Software/License.pm
@@ -202,6 +202,11 @@ The specific license:
 * L<Software::License::Sun>
 * L<Software::License::Zlib>
 
+The L<App::Software::License> module comes with a script
+L<software-license|https://metacpan.org/pod/distribution/App-Software-License/script/software-license>,
+which provides a command-line interface
+to Software::License.
+
 =cut
 
 1;


### PR DESCRIPTION
As an alternative to #45, document that App::Software::License exists on CPAN.
