### PR TITLE
guess_license_from_pod() now knows about Software::License::CC0_1_0

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Software-License
 
 {{$NEXT}}
+        - guess_license_from_pod() now knows about Software::License::CC0_1_0
 
 0.103011  2016-01-16 21:27:53-05:00 America/New_York
         - do not load Sub::Install, since it isn't used!

--- a/lib/Software/LicenseUtils.pm
+++ b/lib/Software/LicenseUtils.pm
@@ -44,6 +44,8 @@ my @phrases = (
   'BSD'                        => 'BSD',
   'Artistic'                   => [ map { "Artistic_$_\_0" } (1..2) ],
   'MIT'                        => 'MIT',
+  'has dedicated the work to the Commons' => 'CC0_1_0',
+  'waiving all of his or her rights to the work worldwide under copyright law' => 'CC0_1_0',
 );
 
 my %meta_keys  = ();

--- a/t/utils.t
+++ b/t/utils.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 5;
+use Test::More tests => 6;
 use Software::LicenseUtils;
 
 {
@@ -187,6 +187,35 @@ END_JSON
   is_deeply(
     \@guesses,
     [ 'Software::License::Perl_5' ],
+    "guessed okay"
+  );
+}
+
+{
+  my $fake_pm = <<'END_PM';
+
+"magic true value";
+__END__
+
+=head1 COPYRIGHT AND LICENSE
+
+唐鳳 has dedicated the work to the Commons by waiving all of his or her rights to the work worldwide under copyright law and all related or neighboring legal rights he or she had in the work, to the extent allowable by law.
+
+Works under CC0 do not require attribution. When citing the work, you should not imply endorsement by the author.
+
+This work is published from Taiwan.
+
+L<http://creativecommons.org/publicdomain/zero/1.0>
+
+=cut
+
+END_PM
+
+  my @guesses = Software::LicenseUtils->guess_license_from_pod($fake_pm);
+
+  is_deeply(
+    \@guesses,
+    [ 'Software::License::CC0_1_0' ],
     "guessed okay"
   );
 }


### PR DESCRIPTION
CPANTS was saying that I didn't have a known license in one of AUDREYT's dists that I released.

Turns out it was because `guess_license_from_pod()` didn't know about `Software::License::CC0_1_0`.

With this PR it does know about it, and my release is now clean `\o/`, but you should look at `@phrases` and see whether you like the way I added it.

I added a test based on the license text from `DateTime::Functions`, the dist in question.
