### PR TITLE
Respect word boundaries

### DIFF
--- a/lib/Software/LicenseUtils.pm
+++ b/lib/Software/LicenseUtils.pm
@@ -106,7 +106,7 @@ sub guess_license_from_pod {
       my ($pattern, $license) = @phrases[ $i .. $i+1 ];
 			$pattern =~ s{\s+}{\\s+}g
 				unless ref $pattern eq 'Regexp';
-			if ( $license_text =~ /$pattern/i ) {
+			if ( $license_text =~ /\b$pattern\b/i ) {
         my $match = $1;
 				# if ( $osi and $license_text =~ /All rights reserved/i ) {
 				# 	warn "LEGAL WARNING: 'All rights reserved' may invalidate Open Source licenses. Consider removing it.";

--- a/t/guess_license_from_pod.t
+++ b/t/guess_license_from_pod.t
@@ -1,0 +1,35 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Software::LicenseUtils;
+
+{
+	# excerpt from BSD License
+	my $license = <<'LICENSE';
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of {{$self->holder}} nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+LICENSE
+
+	my $pod = "=head1 LICENSE\n\n".$license."\n=cut\n";
+	is_deeply(
+		[ Software::LicenseUtils->guess_license_from_pod($pod) ],
+		[ ], # should eventually be [ 'Software::License::BSD' ],
+	);
+}
+
+done_testing;


### PR DESCRIPTION
Not a few modules (eg. https://metacpan.org/pod/POE::Component::Server::Syslog) have a license text without its title in their pod, and CPANTS (with Software::LicenseUtil::guess_license_from_pod) mistakenly guesses that they are under the MIT license, because of a word like "permitted". At least guess_license_from_pod should respect word boundaries. This would also help distinguish FreeBSD from BSD, etc. (It would be nice if it also detects licenses from the license text, but it should be another request).