### PR TITLE
Ignore name in parentheses

### DIFF
--- a/lib/Software/LicenseUtils.pm
+++ b/lib/Software/LicenseUtils.pm
@@ -74,6 +74,9 @@ for my $lib (map { "$_/Software/License" } @INC) {
       $meta2_keys{ $class->meta2_name }{$mod} = undef;
       my $name = $class->name;
       unshift @phrases, qr/\Q$name\E/, [$mod];
+      if ((my $name_without_space = $name) =~ s/\s+\(.+?\)//) {
+        unshift @phrases, qr/\Q$name_without_space\E/, [$mod];
+      }
     };
   }
 }

--- a/t/creative_commons.t
+++ b/t/creative_commons.t
@@ -1,0 +1,22 @@
+#!perl
+
+use strict;
+use warnings;
+use Test::More;
+use Software::LicenseUtils;
+
+BEGIN {
+	eval "require Software::License::CC_BY_1_0; 1"
+	or plan skip_all => "requires Software::License::CCpack to test this";
+}
+
+{
+	my $license = Software::License::CC_BY_1_0->new({holder => 'DUMMY'})->notice;
+	my $pod = "=head1 LICENSE\n\n$license\n=cut\n";
+	is_deeply(
+		[Software::LicenseUtils->guess_license_from_pod($pod)],
+		['Software::License::CC_BY_1_0'],
+	);
+}
+
+done_testing;


### PR DESCRIPTION
The license name returned by several Software::License modules (notably MIT and the ones in CCpack) contains a text in parentheses, which prevents guess_license_from_pod() from detecting the correct license (because license text itself doesn't contain the text in parentheses). This request is to add another phrase without the text. It might be useful to add the text in parentheses, too, (without parentheses), but I haven't included it here. It might also help to add a name without the first "The ".