### PR TITLE
use Parse::CPAN::Meta to make guess_license_from_meta work with META.json

### DIFF
--- a/lib/Software/LicenseUtils.pm
+++ b/lib/Software/LicenseUtils.pm
@@ -8,6 +8,7 @@ package Software::LicenseUtils;
 use File::Spec;
 use IO::Dir;
 use Module::Load;
+use Parse::CPAN::Meta;
 
 =method guess_license_from_pod
 
@@ -141,8 +142,10 @@ sub guess_license_from_meta {
   my ($class, $meta_text) = @_;
   die "can't call guess_license_* in scalar context" unless wantarray;
 
-  my ($license_text) = $meta_text =~ m{\b["']?license["']?\s*:\s*["']?([a-z_0-9]+)["']?}gm;
+  my $meta = Parse::CPAN::Meta->load_string($meta_text);
+  return unless $meta;
 
+  my $license_text = $meta->{license};
   return unless $license_text and my $license = $meta_keys{ $license_text };
 
   return map { "Software::License::$_" } sort keys %$license;

--- a/t/guess_meta_license.t
+++ b/t/guess_meta_license.t
@@ -3,19 +3,27 @@
 use strict;
 use warnings;
 
-use Test::More tests => 26;
+use Test::More tests => 23 * 2 + 3;
 use Software::LicenseUtils;
 use Try::Tiny;
 
 sub _hack_guess_license_from_meta {
-  my $license_str = shift;
+  my $license_meta_str = shift;
   my @guess;
   try {
-    my $hack = 'license : ' . $license_str;
-    @guess = Software::LicenseUtils->guess_license_from_meta($hack);
+    @guess = Software::LicenseUtils->guess_license_from_meta($license_meta_str);
   };
   return @guess;
+}
 
+sub _hack_meta_yaml {
+  my $license_str = shift;
+  "license: $license_str\n";
+}
+
+sub _hack_meta_json {
+  my $license_str = shift;
+  qq({"license": "$license_str"});
 }
 
 my @cpan_meta_spec_licence_name = qw(
@@ -45,8 +53,13 @@ my @cpan_meta_spec_licence_name = qw(
 );
 
 foreach my $license_name (@cpan_meta_spec_licence_name) {
-  my @guess = _hack_guess_license_from_meta($license_name);
-  ok(@guess, "$license_name -> @guess");
+  my $meta_yaml = _hack_meta_yaml($license_name);
+  my @guess_yaml = _hack_guess_license_from_meta($meta_yaml);
+  ok(@guess_yaml, "yaml: $license_name -> @guess_yaml");
+
+  my $meta_json = _hack_meta_json($license_name);
+  my @guess_json = _hack_guess_license_from_meta($meta_json);
+  ok(@guess_json, "json: $license_name -> @guess_json");
 }
 
 is_deeply(


### PR DESCRIPTION
Approach 1 of 2:

* Using Parse::CPAN::Meta to parse the json or yaml file into
  a raw hash
  * use Parse::CPAN::Meta->load_string which handles both
    json and yaml, rather than Parse::CPAN::Meta::LOAD which
    forces yaml parsing.
* Can't use CPAN::Meta because it already parses and normalizes
  license string.

Issue #39