### PR TITLE
Add Unlicense

### DIFF
--- a/lib/Software/License/Unlicense.pm
+++ b/lib/Software/License/Unlicense.pm
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+package Software::License::Unlicense;
+
+use parent 'Software::License';
+# ABSTRACT: Unlicense
+
+sub name      { q(Unlicense) }
+sub url       { q(http://unlicense.org/) }
+sub meta_name  { 'unlicense' }
+sub meta2_name { 'unlicense' }
+
+1;
+__DATA__
+__LICENSE__
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>


### PR DESCRIPTION
GitHub repo can be created with a "Unlicense" LICENSE file.
It would be convenient if Perl ToolChain can match that option.