### PR TITLE
Add the sentence pattern found on the CC0 waiver tool.

### DIFF
--- a/lib/Software/LicenseUtils.pm
+++ b/lib/Software/LicenseUtils.pm
@@ -49,6 +49,7 @@ my @phrases = (
   'MIT'                        => 'MIT',
   'has dedicated the work to the Commons' => 'CC0_1_0',
   'waiving all of his or her rights to the work worldwide under copyright law' => 'CC0_1_0',
+  'has waived all copyright and related or neighboring rights to' => 'CC0_1_0',
 );
 
 my %meta_keys  = ();

--- a/t/utils.t
+++ b/t/utils.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 7;
+use Test::More tests => 8;
 use Software::LicenseUtils;
 
 {
@@ -239,3 +239,26 @@ END_PM
   );
 }
 
+{
+  my $fake_pm = <<'END_PM';
+
+"magic true value";
+__END__
+
+=head1 LICENSE
+
+To the extent possible under law, Kang-min Liu has waived all copyright and related or neighboring rights to JSON::Feed. This work is published from: Taiwan.
+
+https://creativecommons.org/publicdomain/zero/1.0/
+
+=cut
+
+END_PM
+
+  my @guesses = Software::LicenseUtils->guess_license_from_pod($fake_pm);
+  is_deeply(
+    \@guesses,
+    [ 'Software::License::CC0_1_0' ],
+    "guessed okay"
+  );
+}


### PR DESCRIPTION
This commits adds an extra "phrase" to detect_license() for detecting CC0 1.0
in the "LICENSE" section in POD.

The subroutine detect_license does not catch the copyright waiver
generated by a tool provided by creativecommons.org available here:
https://creativecommons.org/choose/zero/

That tool can generate a piece of text for creators to declare
the waiver of copyright. The result is a core phrase like this:

    To the extent possible under law, Someone has waived all copyright and related or neighboring rights to Something. This work is published from: Taiwan.

Here's an HTML version of the the same result: https://creativecommons.org/choose/zero/results?license-class=zero&name=Someone&actor_href=https%3A%2F%example.com&work_title=Something&work_jurisdiction=TW&confirm=confirm&understand=confirm&lang=en&field1=continue&waiver-affirm=affirm