### PR TITLE
add Software::License::None support for guess_license_from_pod

### DIFF
--- a/lib/Software/LicenseUtils.pm
+++ b/lib/Software/LicenseUtils.pm
@@ -49,6 +49,7 @@ my @phrases = (
   'MIT'                        => 'MIT',
   'has dedicated the work to the Commons' => 'CC0_1_0',
   'waiving all of his or her rights to the work worldwide under copyright law' => 'CC0_1_0',
+  'Copyright'                  => 'None',
 );
 
 my %meta_keys  = ();

--- a/t/guess_license_from_pod.t
+++ b/t/guess_license_from_pod.t
@@ -28,7 +28,19 @@ LICENSE
   my $pod = "=head1 LICENSE\n\n".$license."\n=cut\n";
   is_deeply(
     [ Software::LicenseUtils->guess_license_from_pod($pod) ],
-    [ ], # should eventually be [ 'Software::License::BSD' ],
+    [ 'Software::License::None' ], # should eventually be [ 'Software::License::BSD' ],
+  );
+}
+
+{
+  my $license = <<'LICENSE';
+Do what you want.
+LICENSE
+
+  my $pod = "=head1 LICENSE\n\n".$license."\n=cut\n";
+  is_deeply(
+    [ Software::LicenseUtils->guess_license_from_pod($pod) ],
+    [ ],
   );
 }
 


### PR DESCRIPTION
Proposal for Issue #69

In lib/Software/LicenseUtils.pm
    Failing other matches, the word 'copyright' selects
    Software::License::None (restricted)
In t/guess_license_from_pod.t
    Update test