### PR TITLE
Remove spaces from the end of lines

### DIFF
--- a/lib/Software/License/Artistic_1_0.pm
+++ b/lib/Software/License/Artistic_1_0.pm
@@ -66,21 +66,21 @@ Definitions:
 
   - "Package" refers to the collection of files distributed by the Copyright
     Holder, and derivatives of that collection of files created through
-    textual modification. 
+    textual modification.
   - "Standard Version" refers to such a Package if it has not been modified,
     or has been modified in accordance with the wishes of the Copyright
-    Holder. 
+    Holder.
   - "Copyright Holder" is whoever is named in the copyright or copyrights for
-    the package. 
+    the package.
   - "You" is you, if you're thinking about copying or distributing this Package.
   - "Reasonable copying fee" is whatever you can justify on the basis of media
     cost, duplication charges, time of people involved, and so on. (You will
     not be required to justify it to the Copyright Holder, but only to the
-    computing community at large as a market that must bear the fee.) 
+    computing community at large as a market that must bear the fee.)
   - "Freely Available" means that no fee is charged for the item itself, though
     there may be fees involved in handling the item. It also means that
     recipients of the item may redistribute it under the same conditions they
-    received it. 
+    received it.
 
 1. You may make and give away verbatim copies of the source form of the
 Standard Version of this Package without restriction, provided that you

--- a/lib/Software/License/Artistic_2_0.pm
+++ b/lib/Software/License/Artistic_2_0.pm
@@ -33,7 +33,7 @@ You are always permitted to make arrangements wholly outside of this
 license directly with the Copyright Holder of a given Package.  If the
 terms of this license do not permit the full use that you propose to
 make of the Package, you should contact the Copyright Holder and seek
-a different licensing arrangement. 
+a different licensing arrangement.
 
 Definitions
 
@@ -66,7 +66,7 @@ Definitions
 
     "Modified Version" means the Package, if it has been changed, and
     such changes were not explicitly requested by the Copyright
-    Holder. 
+    Holder.
 
     "Original License" means this Artistic License as Distributed with
     the Standard Version of the Package, in its current version or as
@@ -102,7 +102,7 @@ Package will still be considered the Standard Version, and as such
 will be subject to the Original License.
 
 
-Distribution of Modified Versions of the Package as Source 
+Distribution of Modified Versions of the Package as Source
 
 (4)  You may Distribute your Modified Version as Source (either gratis
 or for a Distributor Fee, and with or without a Compiled form of the
@@ -136,7 +136,7 @@ you do at least ONE of the following:
 	Fees are allowed.
 
 
-Distribution of Compiled Forms of the Standard Version 
+Distribution of Compiled Forms of the Standard Version
 or Modified Versions without the Source
 
 (5)  You may Distribute Compiled forms of the Standard Version without
@@ -154,7 +154,7 @@ the Source, provided that you comply with Section 4 with respect to
 the Source of the Modified Version.
 
 
-Aggregating or Linking the Package 
+Aggregating or Linking the Package
 
 (7)  You may aggregate the Package (either the Standard Version or
 Modified Version) with other packages and Distribute the resulting
@@ -171,7 +171,7 @@ include the Package, and Distribute the result without restriction,
 provided the result does not expose a direct interface to the Package.
 
 
-Items That are Not Considered Part of a Modified Version 
+Items That are Not Considered Part of a Modified Version
 
 (9) Works (including, but not limited to, modules and scripts) that
 merely extend or make use of the Package, do not, by themselves, cause

--- a/lib/Software/License/BSD.pm
+++ b/lib/Software/License/BSD.pm
@@ -25,11 +25,11 @@ met:
 
   * Redistributions in binary form must reproduce the above copyright
     notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution. 
+    documentation and/or other materials provided with the distribution.
 
   * Neither the name of {{$self->holder}} nor the names of its
     contributors may be used to endorse or promote products derived from
-    this software without specific prior written permission. 
+    this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED

--- a/lib/Software/License/LGPL_3_0.pm
+++ b/lib/Software/License/LGPL_3_0.pm
@@ -41,7 +41,7 @@ __LICENSE__
 the terms and conditions of version 3 of the GNU General Public
 License, supplemented by the additional permissions listed below.
 
-  0. Additional Definitions. 
+  0. Additional Definitions.
 
   As used herein, "this License" refers to version 3 of the GNU Lesser
 General Public License, and the "GNU GPL" refers to version 3 of the GNU
@@ -142,7 +142,7 @@ the following:
        a copy of the Library already present on the user's computer
        system, and (b) will operate properly with a modified version
        of the Library that is interface-compatible with the Linked
-       Version. 
+       Version.
 
    e) Provide Installation Information, but only if you would otherwise
    be required to provide such information under section 6 of the

--- a/lib/Software/License/Mozilla_1_0.pm
+++ b/lib/Software/License/Mozilla_1_0.pm
@@ -16,57 +16,57 @@ __DATA__
 __LICENSE__
 Mozilla Public License (Version 1.0)
 
-1. Definitions. 
+1. Definitions.
 
      1.1. "Contributor" means each entity that creates or
-     contributes to the creation of Modifications. 
+     contributes to the creation of Modifications.
 
      1.2. "Contributor Version" means the combination of
      the Original Code, prior Modifications used by a
      Contributor, and the Modifications made by that
-     particular Contributor. 
+     particular Contributor.
 
      1.3. "Covered Code" means the Original Code or
      Modifications or the combination of the Original Code
      and Modifications, in each case including portions
-     thereof. 
+     thereof.
 
      1.4. "Electronic Distribution Mechanism" means a
      mechanism generally accepted in the software
      development community for the electronic transfer of
-     data. 
+     data.
 
      1.5. "Executable" means Covered Code in any form
-     other than Source Code. 
+     other than Source Code.
 
      1.6. "Initial Developer" means the individual or entity
      identified as the Initial Developer in the Source Code
-     notice required by Exhibit A. 
+     notice required by Exhibit A.
 
      1.7. "Larger Work" means a work which combines
      Covered Code or portions thereof with code not
-     governed by the terms of this License. 
+     governed by the terms of this License.
 
-     1.8. "License" means this document. 
+     1.8. "License" means this document.
 
      1.9. "Modifications" means any addition to or deletion
      from the substance or structure of either the Original
      Code or any previous Modifications. When Covered
-     Code is released as a series of files, a Modification is: 
+     Code is released as a series of files, a Modification is:
 
           A. Any addition to or deletion from the contents
           of a file containing Original Code or previous
-          Modifications. 
+          Modifications.
 
           B. Any new file that contains any part of the
-          Original Code or previous Modifications. 
+          Original Code or previous Modifications.
 
      1.10. "Original Code" means Source Code of
      computer software code which is described in the
      Source Code notice required by Exhibit A as Original
      Code, and which, at the time of its release under this
      License is not already Covered Code governed by this
-     License. 
+     License.
 
      1.11. "Source Code" means the preferred form of the
      Covered Code for making modifications to it, including
@@ -78,7 +78,7 @@ Mozilla Public License (Version 1.0)
      the Contributor's choice. The Source Code can be in a
      compressed or archival form, provided the appropriate
      decompression or de-archiving software is widely
-     available for no charge. 
+     available for no charge.
 
      1.12. "You" means an individual or a legal entity
      exercising rights under, and complying with all of the
@@ -91,19 +91,19 @@ Mozilla Public License (Version 1.0)
      entity, whether by contract or otherwise, or (b)
      ownership of fifty percent (50%) or more of the
      outstanding shares or beneficial ownership of such
-     entity. 
+     entity.
 
-2. Source Code License. 
+2. Source Code License.
 
-     2.1. The Initial Developer Grant. 
+     2.1. The Initial Developer Grant.
      The Initial Developer hereby grants You a world-wide,
      royalty-free, non-exclusive license, subject to third
-     party intellectual property claims: 
+     party intellectual property claims:
 
           (a) to use, reproduce, modify, display, perform,
           sublicense and distribute the Original Code (or
           portions thereof) with or without Modifications, or
-          as part of a Larger Work; and 
+          as part of a Larger Work; and
 
           (b) under patents now or hereafter owned or
           controlled by Initial Developer, to make, have
@@ -113,19 +113,19 @@ Mozilla Public License (Version 1.0)
           enable You to Utilize the Original Code (or
           portions thereof) and not to any greater extent
           that may be necessary to Utilize further
-          Modifications or combinations. 
+          Modifications or combinations.
 
-     2.2. Contributor Grant. 
+     2.2. Contributor Grant.
      Each Contributor hereby grants You a world-wide,
      royalty-free, non-exclusive license, subject to third
-     party intellectual property claims: 
+     party intellectual property claims:
 
           (a) to use, reproduce, modify, display, perform,
           sublicense and distribute the Modifications
           created by such Contributor (or portions thereof)
           either on an unmodified basis, with other
           Modifications, as Covered Code or as part of a
-          Larger Work; and 
+          Larger Work; and
 
           (b) under patents now or hereafter owned or
           controlled by Contributor, to Utilize the
@@ -134,11 +134,11 @@ Mozilla Public License (Version 1.0)
           reasonably necessary to enable You to Utilize
           the Contributor Version (or portions thereof), and
           not to any greater extent that may be necessary
-          to Utilize further Modifications or combinations. 
+          to Utilize further Modifications or combinations.
 
-3. Distribution Obligations. 
+3. Distribution Obligations.
 
-     3.1. Application of License. 
+     3.1. Application of License.
      The Modifications which You create or to which You
      contribute are governed by the terms of this License,
      including without limitation Section 2.2. The Source
@@ -151,9 +151,9 @@ Mozilla Public License (Version 1.0)
      alters or restricts the applicable version of this License
      or the recipients' rights hereunder. However, You may
      include an additional document offering the additional
-     rights described in Section 3.5. 
+     rights described in Section 3.5.
 
-     3.2. Availability of Source Code. 
+     3.2. Availability of Source Code.
      Any Modification which You create or to which You
      contribute must be made available in Source Code form
      under the terms of this License either on the same
@@ -168,9 +168,9 @@ Mozilla Public License (Version 1.0)
      recipients. You are responsible for ensuring that the
      Source Code version remains available even if the
      Electronic Distribution Mechanism is maintained by a
-     third party. 
+     third party.
 
-     3.3. Description of Modifications. 
+     3.3. Description of Modifications.
      You must cause all Covered Code to which you
      contribute to contain a file documenting the changes
      You made to create that Covered Code and the date of
@@ -180,11 +180,11 @@ Mozilla Public License (Version 1.0)
      including the name of the Initial Developer in (a) the
      Source Code, and (b) in any notice in an Executable
      version or related documentation in which You describe
-     the origin or ownership of the Covered Code. 
+     the origin or ownership of the Covered Code.
 
-     3.4. Intellectual Property Matters 
+     3.4. Intellectual Property Matters
 
-          (a) Third Party Claims. 
+          (a) Third Party Claims.
           If You have knowledge that a party claims an
           intellectual property right in particular
           functionality or code (or its utilization under this
@@ -200,16 +200,16 @@ Mozilla Public License (Version 1.0)
           steps (such as notifying appropriate mailing lists
           or newsgroups) reasonably calculated to inform
           those who received the Covered Code that new
-          knowledge has been obtained. 
+          knowledge has been obtained.
 
-          (b) Contributor APIs. 
+          (b) Contributor APIs.
           If Your Modification is an application
           programming interface and You own or control
           patents which are reasonably necessary to
           implement that API, you must also include this
-          information in the LEGAL file. 
+          information in the LEGAL file.
 
-     3.5. Required Notices. 
+     3.5. Required Notices.
      You must duplicate the notice in Exhibit A in each file
      of the Source Code, and this License in any
      documentation for the Source Code, where You
@@ -231,9 +231,9 @@ Mozilla Public License (Version 1.0)
      indemnify the Initial Developer and every Contributor for
      any liability incurred by the Initial Developer or such
      Contributor as a result of warranty, support, indemnity
-     or liability terms You offer. 
+     or liability terms You offer.
 
-     3.6. Distribution of Executable Versions. 
+     3.6. Distribution of Executable Versions.
      You may distribute Covered Code in Executable form
      only if the requirements of Section 3.1-3.5 have been
      met for that Covered Code, and if You include a notice
@@ -258,17 +258,17 @@ Mozilla Public License (Version 1.0)
      Initial Developer or any Contributor. You hereby agree
      to indemnify the Initial Developer and every Contributor
      for any liability incurred by the Initial Developer or such
-     Contributor as a result of any such terms You offer. 
+     Contributor as a result of any such terms You offer.
 
-     3.7. Larger Works. 
+     3.7. Larger Works.
      You may create a Larger Work by combining Covered
      Code with other code not governed by the terms of this
      License and distribute the Larger Work as a single
      product. In such a case, You must make sure the
      requirements of this License are fulfilled for the Covered
-     Code. 
+     Code.
 
-4. Inability to Comply Due to Statute or Regulation. 
+4. Inability to Comply Due to Statute or Regulation.
 
      If it is impossible for You to comply with any of the
      terms of this License with respect to some or all of the
@@ -281,23 +281,23 @@ Mozilla Public License (Version 1.0)
      of the Source Code. Except to the extent prohibited by
      statute or regulation, such description must be
      sufficiently detailed for a recipient of ordinary skill to be
-     able to understand it. 
+     able to understand it.
 
-5. Application of this License. 
+5. Application of this License.
 
      This License applies to code to which the Initial
      Developer has attached the notice in Exhibit A, and to
-     related Covered Code. 
+     related Covered Code.
 
-6. Versions of the License. 
+6. Versions of the License.
 
-     6.1. New Versions. 
+     6.1. New Versions.
      Netscape Communications Corporation ("Netscape")
      may publish revised and/or new versions of the License
      from time to time. Each version will be given a
-     distinguishing version number. 
+     distinguishing version number.
 
-     6.2. Effect of New Versions. 
+     6.2. Effect of New Versions.
      Once Covered Code has been published under a
      particular version of the License, You may always
      continue to use it under the terms of that version. You
@@ -305,9 +305,9 @@ Mozilla Public License (Version 1.0)
      terms of any subsequent version of the License
      published by Netscape. No one other than Netscape
      has the right to modify the terms applicable to Covered
-     Code created under this License. 
+     Code created under this License.
 
-     6.3. Derivative Works. 
+     6.3. Derivative Works.
      If you create or use a modified version of this License
      (which you may only do in order to apply it to code
      which is not already Covered Code governed by this
@@ -320,9 +320,9 @@ Mozilla Public License (Version 1.0)
      Netscape Public License. (Filling in the name of the
      Initial Developer, Original Code or Contributor in the
      notice described in Exhibit A shall not of themselves
-     be deemed to be modifications of this License.) 
+     be deemed to be modifications of this License.)
 
-7. DISCLAIMER OF WARRANTY. 
+7. DISCLAIMER OF WARRANTY.
 
      COVERED CODE IS PROVIDED UNDER THIS
      LICENSE ON AN "AS IS" BASIS, WITHOUT
@@ -342,9 +342,9 @@ Mozilla Public License (Version 1.0)
      CONSTITUTES AN ESSENTIAL PART OF THIS
      LICENSE. NO USE OF ANY COVERED CODE IS
      AUTHORIZED HEREUNDER EXCEPT UNDER THIS
-     DISCLAIMER. 
+     DISCLAIMER.
 
-8. TERMINATION. 
+8. TERMINATION.
 
      This License and the rights granted hereunder will
      terminate automatically if You fail to comply with terms
@@ -353,9 +353,9 @@ Mozilla Public License (Version 1.0)
      Covered Code which are properly granted shall survive
      any termination of this License. Provisions which, by
      their nature, must remain in effect beyond the
-     termination of this License shall survive. 
+     termination of this License shall survive.
 
-9. LIMITATION OF LIABILITY. 
+9. LIMITATION OF LIABILITY.
 
      UNDER NO CIRCUMSTANCES AND UNDER NO
      LEGAL THEORY, WHETHER TORT (INCLUDING
@@ -381,9 +381,9 @@ Mozilla Public License (Version 1.0)
      ALLOW THE EXCLUSION OR LIMITATION OF
      INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO
      THAT EXCLUSION AND LIMITATION MAY NOT
-     APPLY TO YOU. 
+     APPLY TO YOU.
 
-10. U.S. GOVERNMENT END USERS. 
+10. U.S. GOVERNMENT END USERS.
 
      The Covered Code is a "commercial item," as that term
      is defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of
@@ -393,9 +393,9 @@ Mozilla Public License (Version 1.0)
      48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through
      227.7202-4 (June 1995), all U.S. Government End
      Users acquire Covered Code with only those rights set
-     forth herein. 
+     forth herein.
 
-11. MISCELLANEOUS. 
+11. MISCELLANEOUS.
 
      This License represents the complete agreement
      concerning subject matter hereof. If any provision of
@@ -425,9 +425,9 @@ Mozilla Public License (Version 1.0)
      Goods is expressly excluded. Any law or regulation
      which provides that the language of a contract shall be
      construed against the drafter shall not apply to this
-     License. 
+     License.
 
-12. RESPONSIBILITY FOR CLAIMS. 
+12. RESPONSIBILITY FOR CLAIMS.
 
      Except in cases where another Contributor has failed to
      comply with Section 3.4, You are responsible for
@@ -437,29 +437,29 @@ Mozilla Public License (Version 1.0)
      the revenues you received from utilizing such rights,
      and other relevant factors. You agree to work with
      affected parties to distribute responsibility on an
-     equitable basis. 
+     equitable basis.
 
-EXHIBIT A. 
+EXHIBIT A.
 
      "The contents of this file are subject to the Mozilla
      Public License Version 1.0 (the "License"); you may
      not use this file except in compliance with the License.
      You may obtain a copy of the License at
-     http://www.mozilla.org/MPL/ 
+     http://www.mozilla.org/MPL/
 
      Software distributed under the License is distributed on
      an "AS IS" basis, WITHOUT WARRANTY OF ANY
      KIND, either express or implied. See the License for
      the specific language governing rights and limitations
-     under the License. 
+     under the License.
 
      The Original Code is
-     ______________________________________. 
+     ______________________________________.
 
      The Initial Developer of the Original Code is
      ________________________. Portions created by
      ______________________ are Copyright (C) ______
-     _______________________. All Rights Reserved. 
+     _______________________. All Rights Reserved.
 
      Contributor(s):
-     ______________________________________." 
+     ______________________________________."

--- a/lib/Software/License/Mozilla_1_1.pm
+++ b/lib/Software/License/Mozilla_1_1.pm
@@ -16,70 +16,70 @@ __DATA__
 __LICENSE__
 Mozilla Public License 1.1 (MPL 1.1)
 
-1. Definitions. 
+1. Definitions.
 
      1.0.1. "Commercial Use" means distribution or
      otherwise making the Covered Code available to a third
-     party. 
+     party.
 
      1.1. ''Contributor'' means each entity that creates or
-     contributes to the creation of Modifications. 
+     contributes to the creation of Modifications.
 
      1.2. ''Contributor Version'' means the combination of
      the Original Code, prior Modifications used by a
      Contributor, and the Modifications made by that
-     particular Contributor. 
+     particular Contributor.
 
      1.3. ''Covered Code'' means the Original Code or
      Modifications or the combination of the Original Code
      and Modifications, in each case including portions
-     thereof. 
+     thereof.
 
      1.4. ''Electronic Distribution Mechanism'' means a
      mechanism generally accepted in the software
      development community for the electronic transfer of
-     data. 
+     data.
 
      1.5. ''Executable'' means Covered Code in any form
-     other than Source Code. 
+     other than Source Code.
 
      1.6. ''Initial Developer'' means the individual or entity
      identified as the Initial Developer in the Source Code
-     notice required by Exhibit A. 
+     notice required by Exhibit A.
 
      1.7. ''Larger Work'' means a work which combines
      Covered Code or portions thereof with code not
-     governed by the terms of this License. 
+     governed by the terms of this License.
 
-     1.8. ''License'' means this document. 
+     1.8. ''License'' means this document.
 
      1.8.1. "Licensable" means having the right to grant,
      to the maximum extent possible, whether at the time
      of the initial grant or subsequently acquired, any and
-     all of the rights conveyed herein. 
+     all of the rights conveyed herein.
 
      1.9. ''Modifications'' means any addition to or deletion
      from the substance or structure of either the Original
      Code or any previous Modifications. When Covered
-     Code is released as a series of files, a Modification is: 
+     Code is released as a series of files, a Modification is:
           A. Any addition to or deletion from the contents
           of a file containing Original Code or previous
-          Modifications. 
+          Modifications.
 
           B. Any new file that contains any part of the
-          Original Code or previous Modifications. 
-           
+          Original Code or previous Modifications.
+
      1.10. ''Original Code'' means Source Code of
      computer software code which is described in the
      Source Code notice required by Exhibit A as Original
      Code, and which, at the time of its release under this
      License is not already Covered Code governed by this
-     License. 
+     License.
 
      1.10.1. "Patent Claims" means any patent claim(s),
      now owned or hereafter acquired, including without
      limitation,  method, process, and apparatus claims, in
-     any patent Licensable by grantor. 
+     any patent Licensable by grantor.
 
      1.11. ''Source Code'' means the preferred form of the
      Covered Code for making modifications to it, including
@@ -91,7 +91,7 @@ Mozilla Public License 1.1 (MPL 1.1)
      the Contributor's choice. The Source Code can be in a
      compressed or archival form, provided the appropriate
      decompression or de-archiving software is widely
-     available for no charge. 
+     available for no charge.
 
      1.12. "You'' (or "Your")  means an individual or a legal
      entity exercising rights under, and complying with all of
@@ -106,30 +106,30 @@ Mozilla Public License 1.1 (MPL 1.1)
      outstanding shares or beneficial ownership of such
      entity.
 
-2. Source Code License. 
+2. Source Code License.
 
-     2.1. The Initial Developer Grant. 
+     2.1. The Initial Developer Grant.
      The Initial Developer hereby grants You a world-wide,
      royalty-free, non-exclusive license, subject to third
-     party intellectual property claims: 
+     party intellectual property claims:
           (a)  under intellectual property rights (other than
           patent or trademark) Licensable by Initial
           Developer to use, reproduce, modify, display,
           perform, sublicense and distribute the Original
           Code (or portions thereof) with or without
           Modifications, and/or as part of a Larger Work;
-          and 
+          and
 
           (b) under Patents Claims infringed by the
           making, using or selling of Original Code, to
           make, have made, use, practice, sell, and offer
           for sale, and/or otherwise dispose of the Original
-          Code (or portions thereof). 
-                     
+          Code (or portions thereof).
+
           (c) the licenses granted in this Section 2.1(a)
           and (b) are effective on the date Initial Developer
           first distributes Original Code under the terms of
-          this License. 
+          this License.
 
           (d) Notwithstanding Section 2.1(b) above, no
           patent license is granted: 1) for code that You
@@ -137,13 +137,13 @@ Mozilla Public License 1.1 (MPL 1.1)
           the Original Code;  or 3) for infringements
           caused by: i) the modification of the Original
           Code or ii) the combination of the Original Code
-          with other software or devices. 
-           
-     2.2. Contributor Grant. 
+          with other software or devices.
+
+     2.2. Contributor Grant.
      Subject to third party intellectual property claims, each
      Contributor hereby grants You a world-wide,
-     royalty-free, non-exclusive license 
-            
+     royalty-free, non-exclusive license
+
           (a)  under intellectual property rights (other than
           patent or trademark) Licensable by Contributor,
           to use, reproduce, modify, display, perform,
@@ -151,7 +151,7 @@ Mozilla Public License 1.1 (MPL 1.1)
           created by such Contributor (or portions thereof)
           either on an unmodified basis, with other
           Modifications, as Covered Code and/or as part
-          of a Larger Work; and 
+          of a Larger Work; and
 
           (b) under Patent Claims infringed by the
           making, using, or selling of  Modifications made
@@ -163,18 +163,18 @@ Mozilla Public License 1.1 (MPL 1.1)
           Contributor (or portions thereof); and 2) the
           combination of  Modifications made by that
           Contributor with its Contributor Version (or
-          portions of such combination). 
+          portions of such combination).
 
           (c) the licenses granted in Sections 2.2(a) and
           2.2(b) are effective on the date Contributor first
-          makes Commercial Use of the Covered Code. 
+          makes Commercial Use of the Covered Code.
 
           (d)    Notwithstanding Section 2.2(b) above, no
           patent license is granted: 1) for any code that
           Contributor has deleted from the Contributor
           Version; 2)  separate from the Contributor
           Version;  3)  for infringements caused by: i) third
-          party modifications of Contributor Version or ii) 
+          party modifications of Contributor Version or ii)
           the combination of Modifications made by that
           Contributor with other software  (except as part
           of the Contributor Version) or other devices; or
@@ -183,9 +183,9 @@ Mozilla Public License 1.1 (MPL 1.1)
           that Contributor.
 
 
-3. Distribution Obligations. 
+3. Distribution Obligations.
 
-     3.1. Application of License. 
+     3.1. Application of License.
      The Modifications which You create or to which You
      contribute are governed by the terms of this License,
      including without limitation Section 2.2. The Source
@@ -198,9 +198,9 @@ Mozilla Public License 1.1 (MPL 1.1)
      alters or restricts the applicable version of this License
      or the recipients' rights hereunder. However, You may
      include an additional document offering the additional
-     rights described in Section 3.5. 
+     rights described in Section 3.5.
 
-     3.2. Availability of Source Code. 
+     3.2. Availability of Source Code.
      Any Modification which You create or to which You
      contribute must be made available in Source Code
      form under the terms of this License either on the
@@ -215,9 +215,9 @@ Mozilla Public License 1.1 (MPL 1.1)
      such recipients. You are responsible for ensuring that
      the Source Code version remains available even if the
      Electronic Distribution Mechanism is maintained by a
-     third party. 
+     third party.
 
-     3.3. Description of Modifications. 
+     3.3. Description of Modifications.
      You must cause all Covered Code to which You
      contribute to contain a file documenting the changes
      You made to create that Covered Code and the date of
@@ -227,10 +227,10 @@ Mozilla Public License 1.1 (MPL 1.1)
      including the name of the Initial Developer in (a) the
      Source Code, and (b) in any notice in an Executable
      version or related documentation in which You describe
-     the origin or ownership of the Covered Code. 
+     the origin or ownership of the Covered Code.
 
-     3.4. Intellectual Property Matters 
-          (a) Third Party Claims. 
+     3.4. Intellectual Property Matters
+          (a) Third Party Claims.
           If Contributor has knowledge that a license
           under a third party's intellectual property rights
           is required to exercise the rights granted by
@@ -248,17 +248,17 @@ Mozilla Public License 1.1 (MPL 1.1)
           notifying appropriate mailing lists or
           newsgroups) reasonably calculated to inform
           those who received the Covered Code that new
-          knowledge has been obtained. 
+          knowledge has been obtained.
 
-          (b) Contributor APIs. 
+          (b) Contributor APIs.
           If Contributor's Modifications include an
           application programming interface and
           Contributor has knowledge of patent licenses
           which are reasonably necessary to implement
           that API, Contributor must also include this
-          information in the LEGAL file. 
-           
-               (c)    Representations. 
+          information in the LEGAL file.
+
+               (c)    Representations.
           Contributor represents that, except as disclosed
           pursuant to Section 3.4(a) above, Contributor
           believes that Contributor's Modifications are
@@ -267,7 +267,7 @@ Mozilla Public License 1.1 (MPL 1.1)
           rights conveyed by this License.
 
 
-     3.5. Required Notices. 
+     3.5. Required Notices.
      You must duplicate the notice in Exhibit A in each file
      of the Source Code.  If it is not possible to put such
      notice in a particular Source Code file due to its
@@ -290,9 +290,9 @@ Mozilla Public License 1.1 (MPL 1.1)
      agree to indemnify the Initial Developer and every
      Contributor for any liability incurred by the Initial
      Developer or such Contributor as a result of warranty,
-     support, indemnity or liability terms You offer. 
+     support, indemnity or liability terms You offer.
 
-     3.6. Distribution of Executable Versions. 
+     3.6. Distribution of Executable Versions.
      You may distribute Covered Code in Executable form
      only if the requirements of Section 3.1-3.5 have been
      met for that Covered Code, and if You include a notice
@@ -318,9 +318,9 @@ Mozilla Public License 1.1 (MPL 1.1)
      You hereby agree to indemnify the Initial Developer and
      every Contributor for any liability incurred by the Initial
      Developer or such Contributor as a result of any such
-     terms You offer. 
+     terms You offer.
 
-     3.7. Larger Works. 
+     3.7. Larger Works.
      You may create a Larger Work by combining Covered
      Code with other code not governed by the terms of this
      License and distribute the Larger Work as a single
@@ -328,7 +328,7 @@ Mozilla Public License 1.1 (MPL 1.1)
      requirements of this License are fulfilled for the Covered
      Code.
 
-4. Inability to Comply Due to Statute or Regulation. 
+4. Inability to Comply Due to Statute or Regulation.
 
      If it is impossible for You to comply with any of the
      terms of this License with respect to some or all of the
@@ -343,21 +343,21 @@ Mozilla Public License 1.1 (MPL 1.1)
      must be sufficiently detailed for a recipient of ordinary
      skill to be able to understand it.
 
-5. Application of this License. 
+5. Application of this License.
 
      This License applies to code to which the Initial
      Developer has attached the notice in Exhibit A and to
      related Covered Code.
 
-6. Versions of the License. 
+6. Versions of the License.
 
-     6.1. New Versions. 
+     6.1. New Versions.
      Netscape Communications Corporation (''Netscape'')
      may publish revised and/or new versions of the License
      from time to time. Each version will be given a
-     distinguishing version number. 
+     distinguishing version number.
 
-     6.2. Effect of New Versions. 
+     6.2. Effect of New Versions.
      Once Covered Code has been published under a
      particular version of the License, You may always
      continue to use it under the terms of that version. You
@@ -365,9 +365,9 @@ Mozilla Public License 1.1 (MPL 1.1)
      terms of any subsequent version of the License
      published by Netscape. No one other than Netscape
      has the right to modify the terms applicable to Covered
-     Code created under this License. 
+     Code created under this License.
 
-     6.3. Derivative Works. 
+     6.3. Derivative Works.
      If You create or use a modified version of this License
      (which you may only do in order to apply it to code
      which is not already Covered Code governed by this
@@ -384,7 +384,7 @@ Mozilla Public License 1.1 (MPL 1.1)
      not of themselves be deemed to be modifications of
      this License.)
 
-7. DISCLAIMER OF WARRANTY. 
+7. DISCLAIMER OF WARRANTY.
 
      COVERED CODE IS PROVIDED UNDER THIS
      LICENSE ON AN "AS IS'' BASIS, WITHOUT
@@ -406,7 +406,7 @@ Mozilla Public License 1.1 (MPL 1.1)
      AUTHORIZED HEREUNDER EXCEPT UNDER THIS
      DISCLAIMER.
 
-8. TERMINATION. 
+8. TERMINATION.
 
      8.1.  This License and the rights granted hereunder will
      terminate automatically if You fail to comply with terms
@@ -415,21 +415,21 @@ Mozilla Public License 1.1 (MPL 1.1)
      Covered Code which are properly granted shall survive
      any termination of this License. Provisions which, by
      their nature, must remain in effect beyond the
-     termination of this License shall survive. 
+     termination of this License shall survive.
 
      8.2.  If You initiate litigation by asserting a patent
      infringement claim (excluding declatory judgment
      actions) against Initial Developer or a Contributor (the
      Initial Developer or Contributor against whom You file
      such action is referred to as "Participant")  alleging
-     that: 
+     that:
 
      (a)  such Participant's Contributor Version directly or
      indirectly infringes any patent, then any and all rights
      granted by such Participant to You under Sections 2.1
      and/or 2.2 of this License shall, upon 60 days notice
      from Participant terminate prospectively, unless if
-     within 60 days after receipt of notice You either: (i) 
+     within 60 days after receipt of notice You either: (i)
      agree in writing to pay Participant a mutually agreeable
      reasonable royalty for Your past and future use of
      Modifications made by such Participant, or (ii)
@@ -440,7 +440,7 @@ Mozilla Public License 1.1 (MPL 1.1)
      the parties or the litigation claim is not withdrawn, the
      rights granted by Participant to You under Sections 2.1
      and/or 2.2 automatically terminate at the expiration of
-     the 60 day notice period specified above. 
+     the 60 day notice period specified above.
 
      (b)  any software, hardware, or device, other than such
      Participant's Contributor Version, directly or indirectly
@@ -448,7 +448,7 @@ Mozilla Public License 1.1 (MPL 1.1)
      such Participant under Sections 2.1(b) and 2.2(b) are
      revoked effective as of the date You first made, used,
      sold, distributed, or had made, Modifications made by
-     that Participant. 
+     that Participant.
 
      8.3.  If You assert a patent infringement claim against
      Participant alleging that such Participant's Contributor
@@ -458,7 +458,7 @@ Mozilla Public License 1.1 (MPL 1.1)
      litigation, then the reasonable value of the licenses
      granted by such Participant under Sections 2.1 or 2.2
      shall be taken into account in determining the amount
-     or value of any payment or license. 
+     or value of any payment or license.
 
      8.4.  In the event of termination under Sections 8.1 or
      8.2 above,  all end user license agreements (excluding
@@ -466,7 +466,7 @@ Mozilla Public License 1.1 (MPL 1.1)
      granted by You or any distributor hereunder prior to
      termination shall survive termination.
 
-9. LIMITATION OF LIABILITY. 
+9. LIMITATION OF LIABILITY.
 
      UNDER NO CIRCUMSTANCES AND UNDER NO
      LEGAL THEORY, WHETHER TORT (INCLUDING
@@ -493,7 +493,7 @@ Mozilla Public License 1.1 (MPL 1.1)
      CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION
      AND LIMITATION MAY NOT APPLY TO YOU.
 
-10. U.S. GOVERNMENT END USERS. 
+10. U.S. GOVERNMENT END USERS.
 
      The Covered Code is a ''commercial item,'' as that term
      is defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of
@@ -505,7 +505,7 @@ Mozilla Public License 1.1 (MPL 1.1)
      Users acquire Covered Code with only those rights set
      forth herein.
 
-11. MISCELLANEOUS. 
+11. MISCELLANEOUS.
 
      This License represents the complete agreement
      concerning subject matter hereof. If any provision of
@@ -530,7 +530,7 @@ Mozilla Public License 1.1 (MPL 1.1)
      construed against the drafter shall not apply to this
      License.
 
-12. RESPONSIBILITY FOR CLAIMS. 
+12. RESPONSIBILITY FOR CLAIMS.
 
      As between Initial Developer and the Contributors,
      each party is responsible for claims and damages
@@ -541,7 +541,7 @@ Mozilla Public License 1.1 (MPL 1.1)
      intended or shall be deemed to constitute any
      admission of liability.
 
-13. MULTIPLE-LICENSED CODE. 
+13. MULTIPLE-LICENSED CODE.
 
      Initial Developer may designate portions of the Covered
      Code as "Multiple-Licensed".  "Multiple-Licensed"
@@ -551,31 +551,31 @@ Mozilla Public License 1.1 (MPL 1.1)
      Initial Developer in the file described in Exhibit A.
 
 
-EXHIBIT A -Mozilla Public License. 
+EXHIBIT A -Mozilla Public License.
 
      ``The contents of this file are subject to the Mozilla
      Public License Version 1.1 (the "License"); you may
      not use this file except in compliance with the License.
-     You may obtain a copy of the License at 
-     http://www.mozilla.org/MPL/ 
+     You may obtain a copy of the License at
+     http://www.mozilla.org/MPL/
 
      Software distributed under the License is distributed on
-     an "AS IS" basis, WITHOUT WARRANTY OF 
+     an "AS IS" basis, WITHOUT WARRANTY OF
      ANY KIND, either express or implied. See the License
-     for the specific language governing rights and 
-     limitations under the License. 
+     for the specific language governing rights and
+     limitations under the License.
 
      The Original Code is
-     ______________________________________. 
+     ______________________________________.
 
      The Initial Developer of the Original Code is
-     ________________________. Portions created by 
+     ________________________. Portions created by
       ______________________ are Copyright (C) ______
-     _______________________. All Rights 
-     Reserved. 
+     _______________________. All Rights
+     Reserved.
 
      Contributor(s):
-     ______________________________________. 
+     ______________________________________.
 
      Alternatively, the contents of this file may be used
      under the terms of the _____ license (the  "[___]
@@ -588,10 +588,10 @@ EXHIBIT A -Mozilla Public License.
      replace  them with the notice and other provisions
      required by the [___] License.  If you do not delete the
      provisions above, a recipient may use your version of
-     this file under either the MPL or the [___] License." 
+     this file under either the MPL or the [___] License."
 
      [NOTE: The text of this Exhibit A may differ slightly
      from the text of the notices in the Source Code files of
      the Original Code. You should use the text of this
      Exhibit A rather than the text found in the Original
-     Code Source Code for Your Modifications.] 
+     Code Source Code for Your Modifications.]

--- a/lib/Software/License/Mozilla_2_0.pm
+++ b/lib/Software/License/Mozilla_2_0.pm
@@ -51,7 +51,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"

--- a/lib/Software/License/QPL_1_0.pm
+++ b/lib/Software/License/QPL_1_0.pm
@@ -20,7 +20,7 @@ Version 1.0
 
 Copyright (C) 1999 Trolltech AS, Norway.
 Everyone is permitted to copy and distribute this license
-document. 
+document.
 
 The intent of this license is to establish freedom to share and
 change the software regulated by this license under the open

--- a/lib/Software/License/Sun.pm
+++ b/lib/Software/License/Sun.pm
@@ -17,58 +17,58 @@ __DATA__
 __LICENSE__
 Sun Internet Standards Source License (SISSL)
 
-1.0 DEFINITIONS 
+1.0 DEFINITIONS
 
 1.1 "Commercial Use" means distribution or otherwise making the
-Original Code available to a third party. 
+Original Code available to a third party.
 
 1.2 "Contributor Version" means the combination of the Original
-Code, and the Modifications made by that particular Contributor. 
+Code, and the Modifications made by that particular Contributor.
 
 1.3 "Electronic Distribution Mechanism" means a mechanism
 generally accepted in the software development community for the
-electronic transfer of data. 
+electronic transfer of data.
 
 1.4 "Executable" means Original Code in any form other than
-Source Code. 
+Source Code.
 
 1.5 "Initial Developer" means the individual or entity identified as
 the Initial Developer in the Source Code notice required by Exhibit
-A. 
+A.
 
 1.6 "Larger Work" means a work which combines Original Code or
 portions thereof with code not governed by the terms of this License.
 
-1.7 "License" means this document. 
+1.7 "License" means this document.
 
 1.8 "Licensable" means having the right to grant, to the maximum
 extent possible, whether at the time of the initial grant or
-subsequently acquired, any and all of the rights conveyed herein. 
+subsequently acquired, any and all of the rights conveyed herein.
 
 1.9 "Modifications" means any addition to or deletion from the
 substance or structure of either the Original Code or any previous
-Modifications. A Modification is: 
+Modifications. A Modification is:
 
      A. Any addition to or deletion from the contents of a file
-     containing Original Code or previous Modifications. 
+     containing Original Code or previous Modifications.
 
      B. Any new file that contains any part of the Original Code or
      previous Modifications.
 
 1.10 "Original Code" means Source Code of computer software
 code which is described in the Source Code notice required by
-Exhibit A as Original Code. 
+Exhibit A as Original Code.
 
 1.11 "Patent Claims" means any patent claim(s), now owned or
 hereafter acquired, including without limitation, method, process,
-and apparatus claims, in any patent Licensable by grantor. 
+and apparatus claims, in any patent Licensable by grantor.
 
 1.12 "Source Code" means the preferred form of the Original Code
 for making modifications to it, including all modules it contains, plus
 any associated interface definition files, or scripts used to control
-compilation and installation of an Executable. 
+compilation and installation of an Executable.
 
-1.13 "Standards" means the standards identified in Exhibit B. 
+1.13 "Standards" means the standards identified in Exhibit B.
 
 1.14 "You" (or "Your") means an individual or a legal entity
 exercising rights under, and complying with all of the terms of, this
@@ -79,29 +79,29 @@ this definition, "control'' means (a) the power, direct or indirect, to
 cause the direction or management of such entity, whether by
 contract or otherwise, or (b) ownership of more than fifty percent
 (50%) of the outstanding shares or beneficial ownership of such
-entity. 
+entity.
 
-2.0 SOURCE CODE LICENSE 
+2.0 SOURCE CODE LICENSE
 
-2.1 The Initial Developer Grant 
+2.1 The Initial Developer Grant
 The Initial Developer hereby grants You a world-wide, royalty-free,
 non-exclusive license, subject to third party intellectual property
-claims:  
+claims:
 
      (a) under intellectual property rights (other than patent or
      trademark) Licensable by Initial Developer to use, reproduce,
      modify, display, perform, sublicense and distribute the
      Original Code (or portions thereof) with or without
-     Modifications, and/or as part of a Larger Work; and 
+     Modifications, and/or as part of a Larger Work; and
 
      (b) under Patents Claims infringed by the making, using or
      selling of Original Code, to make, have made, use, practice,
      sell, and offer for sale, and/or otherwise dispose of the
-     Original Code (or portions thereof). 
+     Original Code (or portions thereof).
 
      (c) the licenses granted in this Section 2.1(a) and (b) are
      effective on the date Initial Developer first distributes Original
-     Code under the terms of this License. 
+     Code under the terms of this License.
 
      (d) Notwithstanding Section 2.1(b) above, no patent license
      is granted: 1) for code that You delete from the Original
@@ -109,11 +109,11 @@ claims:
      infringements caused by: i) the modification of the Original
      Code or ii) the combination of the Original Code with other
      software or devices, including but not limited to
-     Modifications. 
+     Modifications.
 
-3.0 DISTRIBUTION OBLIGATIONS 
+3.0 DISTRIBUTION OBLIGATIONS
 
-3.1 Application of License. 
+3.1 Application of License.
 The Source Code version of Original Code may be distributed only
 under the terms of this License or a future version of this License
 released under Section 6.1, and You must include a copy of this
@@ -133,9 +133,9 @@ Modifications in Source Code form, and to make any such deviation
 and reference implementation or Modifications available to all third
 parties under the same terms as this license on a royalty free basis
 within thirty (30) days of Your first customer shipment of Your
-Modifications. 
+Modifications.
 
-3.2 Required Notices. 
+3.2 Required Notices.
 You must duplicate the notice in Exhibit A in each file of the
 Source Code. If it is not possible to put such notice in a particular
 Source Code file due to its structure, then You must include such
@@ -153,9 +153,9 @@ absolutely clear than any such warranty, support, indemnity or
 liability obligation is offered by You alone, and You hereby agree to
 indemnify the Initial Developer for any liability incurred by the Initial
 Developer as a result of warranty, support, indemnity or liability
-terms You offer. 
+terms You offer.
 
-3.3 Distribution of Executable Versions. 
+3.3 Distribution of Executable Versions.
 You may distribute Original Code in Executable and Source form
 only if the requirements of Sections 3.1 and 3.2 have been met for
 that Original Code, and if You include a notice stating that the
@@ -172,14 +172,14 @@ versions under a different license You must make it absolutely clear
 that any terms which differ from this License are offered by You
 alone, not by the Initial Developer. You hereby agree to indemnify
 the Initial Developer for any liability incurred by the Initial Developer
-as a result of any such terms You offer. 
+as a result of any such terms You offer.
 
-3.4 Larger Works. 
+3.4 Larger Works.
 You may create a Larger Work by combining Original Code with
 other code not governed by the terms of this License and distribute
 the Larger Work as a single product. In such a case, You must
 make sure the requirements of this License are fulfilled for the
-Original Code. 
+Original Code.
 
 4.0 INABILITY TO COMPLY DUE TO STATUTE OR REGULATION
 
@@ -192,30 +192,30 @@ must be included in the LEGAL file described in Section 3.2 and
 must be included with all distributions of the Source Code. Except
 to the extent prohibited by statute or regulation, such description
 must be sufficiently detailed for a recipient of ordinary skill to be
-able to understand it. 
+able to understand it.
 
-5.0 APPLICATION OF THIS LICENSE 
+5.0 APPLICATION OF THIS LICENSE
 
 This License applies to code to which the Initial Developer has
 attached the notice in Exhibit A and to related Modifications as set
-out in Section 3.1. 
+out in Section 3.1.
 
-6.0 VERSIONS OF THE LICENSE 
+6.0 VERSIONS OF THE LICENSE
 
-6.1 New Versions. 
+6.1 New Versions.
 Sun may publish revised and/or new versions of the License from
 time to time. Each version will be given a distinguishing version
-number. 
+number.
 
-6.2 Effect of New Versions. 
+6.2 Effect of New Versions.
 Once Original Code has been published under a particular version of
 the License, You may always continue to use it under the terms of
 that version. You may also choose to use such Original Code under
 the terms of any subsequent version of the License published by
 Sun. No one other than Sun has the right to modify the terms
-applicable to Original Code. 
+applicable to Original Code.
 
-7.0 DISCLAIMER OF WARRANTY 
+7.0 DISCLAIMER OF WARRANTY
 
 ORIGINAL CODE IS PROVIDED UNDER THIS LICENSE ON AN
 "AS IS" BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER
@@ -230,9 +230,9 @@ ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR
 OR CORRECTION. THIS DISCLAIMER OF WARRANTY
 CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE
 OF ANY ORIGINAL CODE IS AUTHORIZED HEREUNDER EXCEPT
-UNDER THIS DISCLAIMER. 
+UNDER THIS DISCLAIMER.
 
-8.0 TERMINATION 
+8.0 TERMINATION
 
 8.1 This License and the rights granted hereunder will terminate
 automatically if You fail to comply with terms herein and fail to cure
@@ -240,14 +240,14 @@ such breach within 30 days of becoming aware of the breach. All
 sublicenses to the Original Code which are properly granted shall
 survive any termination of this License. Provisions which, by their
 nature, must remain in effect beyond the termination of this License
-shall survive. 
+shall survive.
 
 8.2 In the event of termination under Section 8.1 above, all end user
 license agreements (excluding distributors and resellers) which have
 been validly granted by You or any distributor hereunder prior to
-termination shall survive termination. 
+termination shall survive termination.
 
-9.0 LIMIT OF LIABILITY 
+9.0 LIMIT OF LIABILITY
 
 UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY,
 WHETHER TORT (INCLUDING NEGLIGENCE), CONTRACT, OR
@@ -268,9 +268,9 @@ APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME
 JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR
 LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES,
 SO THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO
-YOU. 
+YOU.
 
-10.0 U.S. GOVERNMENT END USERS 
+10.0 U.S. GOVERNMENT END USERS
 
 U.S. Government: If this Software is being acquired by or on behalf
 of the U.S. Government or by a U.S. Government prime contractor
@@ -278,9 +278,9 @@ or subcontractor (at any tier), then the Government's rights in the
 Software and accompanying documentation shall be only as set
 forth in this license; this is in accordance with 48 C.F.R. 227.7201
 through 227.7202-4 (for Department of Defense (DoD) acquisitions)
-and with 48 C.F.R. 2.101 and 12.212 (for non-DoD acquisitions). 
+and with 48 C.F.R. 2.101 and 12.212 (for non-DoD acquisitions).
 
-11.0 MISCELLANEOUS 
+11.0 MISCELLANEOUS
 
 This License represents the complete agreement concerning
 subject matter hereof. If any provision of this License is held to be
@@ -299,15 +299,15 @@ expenses. The application of the United Nations Convention on
 Contracts for the International Sale of Goods is expressly excluded.
 Any law or regulation which provides that the language of a contract
 shall be construed against the drafter shall not apply to this
-License. 
+License.
 
-EXHIBIT A - Sun Standards License 
+EXHIBIT A - Sun Standards License
 
 "The contents of this file are subject to the Sun Standards
 
 License Version 1.1 (the "License");
 
-You may not use this file except in compliance with the 
+You may not use this file except in compliance with the
 
 License. You may obtain a copy of the
 
@@ -315,9 +315,9 @@ License at _______________________________.
 
 
 
-Software distributed under the License is distributed on 
+Software distributed under the License is distributed on
 
-an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either 
+an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either
 
 express or implied. See the License for the specific
 
@@ -329,7 +329,7 @@ The Original Code is ______________________________________.
 
 
 
-The Initial Developer of the Original Code is: 
+The Initial Developer of the Original Code is:
 
 Sun Microsystems, Inc..
 
@@ -350,13 +350,13 @@ All Rights Reserved.
 Contributor(s): _______________________________________
 
 
-EXHIBIT B - Standards 
+EXHIBIT B - Standards
 
-The Standard is defined as the following: 
+The Standard is defined as the following:
 
 OpenOffice.org XML File Format Specification, located at
-http://xml.openoffice.org 
+http://xml.openoffice.org
 
 OpenOffice.org Application Programming Interface Specification,
-located at 
+located at
 http://api.openoffice.org


### PR DESCRIPTION
End of line spaces in licenses show up on automated author tests