### PR TITLE
add Software::License::None support for guess_license_from_pod

### DIFF
--- a/lib/Software/LicenseUtils.pm
+++ b/lib/Software/LicenseUtils.pm
@@ -52,6 +52,7 @@ my @phrases = (
   'has dedicated the work to the Commons' => 'CC0_1_0',
   'waiving all of his or her rights to the work worldwide under copyright law' => 'CC0_1_0',
   'has waived all copyright and related or neighboring rights to' => 'CC0_1_0',
+  'No license is granted to other entities' => 'None',
 );
 
 my %meta_keys  = ();


### PR DESCRIPTION
Simpler (no test changes), and is currently conflict free.
This allows me to use App::ModuleBuildTiny mbtiny on modules that will not leave $WORK