### PR TITLE
use valid SPDX identifier for BSD license

### DIFF
--- a/lib/Software/License/BSD.pm
+++ b/lib/Software/License/BSD.pm
@@ -9,7 +9,7 @@ sub name { 'The (three-clause) BSD License' }
 sub url  { 'http://opensource.org/licenses/BSD-3-Clause' }
 sub meta_name  { 'bsd' }
 sub meta2_name { 'bsd' }
-sub spdx_expression  { 'BSD' }
+sub spdx_expression  { 'BSD-3-Clause' }
 
 1;
 __DATA__

--- a/t/spdx-expression.t
+++ b/t/spdx-expression.t
@@ -57,7 +57,7 @@ is (scalar(Software::License::Artistic_2_0->spdx_expression()),
 );
 
 is (scalar(Software::License::BSD->spdx_expression()),
-    'BSD',
+    'BSD-3-Clause',
     "BSD->spdx_expression() is OK."
 );
 


### PR DESCRIPTION
Currently, `Software::License::BSD::spdx_expression` returns 'BSD', which is not a valid SPDX identifier. This PR changes this to 'BSD-3-Clause,' which according to the url in the code is the intended license.