### PR TITLE
CPAN::Meta v1 "gpl" license is explicitly GPL v2

### DIFF
--- a/lib/Software/License/GPL_1.pm
+++ b/lib/Software/License/GPL_1.pm
@@ -7,7 +7,7 @@ use parent 'Software::License';
 
 sub name { 'The GNU General Public License, Version 1, February 1989' }
 sub url  { 'http://www.gnu.org/licenses/old-licenses/gpl-1.0.txt' }
-sub meta_name  { 'gpl' }
+sub meta_name  { 'open_source' }
 sub meta2_name { 'gpl_1' }
 sub spdx_expression  { 'GPL-1.0-only' }
 

--- a/lib/Software/License/GPL_3.pm
+++ b/lib/Software/License/GPL_3.pm
@@ -7,7 +7,7 @@ use parent 'Software::License';
 
 sub name { 'The GNU General Public License, Version 3, June 2007' }
 sub url  { 'http://www.gnu.org/licenses/gpl-3.0.txt' }
-sub meta_name  { 'gpl' }
+sub meta_name  { 'open_source' }
 sub meta2_name { 'gpl_3' }
 sub spdx_expression  { 'GPL-3.0-only' }
 

--- a/t/utils.t
+++ b/t/utils.t
@@ -142,9 +142,7 @@ END_YAML
   is_deeply(
     \@guesses,
     [ qw(
-      Software::License::GPL_1
       Software::License::GPL_2
-      Software::License::GPL_3
     ) ],
     "guessed okay"
   );


### PR DESCRIPTION
In version 1.0 through 1.4, the license "gpl" refers the GPL v2 license. It should not be used for code licensed as GPL v1 or GPL v3. There is a fixed list of allowed license values for meta v1, so the only fitting option for GPLv1 or GPLv3 is "open_source", referring to any OSI approved license.