### PR TITLE
Improve recognition for Apache 1.1 & 2.0

### DIFF
--- a/lib/Software/LicenseUtils.pm
+++ b/lib/Software/LicenseUtils.pm
@@ -52,10 +52,10 @@ my @phrases = (
   'has dedicated the work to the Commons' => 'CC0_1_0',
   'waiving all of his or her rights to the work worldwide under copyright law' => 'CC0_1_0',
   'has waived all copyright and related or neighboring rights to' => 'CC0_1_0',
-  'apache(?: |-)1.1' => "Apache_1_1",
-  "Apache Software License(\\s)+Version 1.1" => "Apache_1_1",
-  'apache(?: |-)2.0' => "Apache_2_0",
-  "Apache License(\\s)+Version 2.0" => "Apache_2_0",
+  'apache[- ]1.1' => "Apache_1_1",
+  "Apache Software License[,\\s]+Version 1.1" => "Apache_1_1",
+  'apache[- ]2.0' => "Apache_2_0",
+  "Apache License[,\\s]+Version 2.0" => "Apache_2_0",
   'No license is granted to other entities' => 'None',
 );
 

--- a/t/guess_license_from_pod.t
+++ b/t/guess_license_from_pod.t
@@ -52,8 +52,18 @@ Version 1.1
 Copyright (c) 2000 The Apache Software Foundation.  All rights reserved.
 LICENSE
 
+  # https://www.apache.org/licenses/LICENSE-1.1
+  # "An example Apache Software License 1.1 file"
+  my $license_as_example = <<'LICENSE_AS_EXAMPLE';
+The Apache Software License, Version 1.1
+
+Copyright (c) 2000 The Apache Software Foundation.  All rights
+reserved.
+LICENSE_AS_EXAMPLE
+
   my @license_strings = (
     $license,
+    $license_as_example,
     "apache 1.1", "Apache 1.1", "APACHE 1.1",
     "apache-1.1", "Apache-1.1", "APACHE-1.1",
   );
@@ -78,8 +88,29 @@ subtest 'apache_2_0' => sub {
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 LICENSE
 
+  # https://www.apache.org/licenses/LICENSE-2.0 suggests:
+  #
+  #    To apply the Apache License to specific files in your work, attach
+  #    the following boilerplate declaration, ...
+  my $boilerplate = << 'BOILERPLATE';
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+BOILERPLATE
+
   my @license_strings = (
     $license,
+    $boilerplate,
     "apache 2.0", "Apache 2.0", "APACHE 2.0",
     "apache-2.0", "Apache-2.0", "APACHE-2.0",
   );


### PR DESCRIPTION
Add more test inputs for the two Apache licenses, taking into account what is presented as example or suggested in the official web pages about the two licenses:

- https://www.apache.org/licenses/LICENSE-1.1
- https://www.apache.org/licenses/LICENSE-2.0#apply

This should hopefully cover the "actual" request in #72.

The added tests both fail, hence the proposed changes to the relevant `@phrases` inside Software::LicenseUtils, as well as a cleanup.