### PR TITLE
update GPL v1 text to current version

### DIFF
--- a/lib/Software/License/GPL_1.pm
+++ b/lib/Software/License/GPL_1.pm
@@ -18,7 +18,7 @@ __LICENSE__
                      Version 1, February 1989
 
  Copyright (C) 1989 Free Software Foundation, Inc.
- 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+                    <https://fsf.org/>
 
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
@@ -232,8 +232,7 @@ the exclusion of warranty; and each file should have at least the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston MA  02110-1301 USA
+    along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
 Also add information on how to contact you by electronic and paper mail.
@@ -260,7 +259,7 @@ necessary.  Here a sample; alter the names:
   program `Gnomovision' (a program to direct compilers to make passes
   at assemblers) written by James Hacker.
 
-  <signature of Ty Coon>, 1 April 1989
-  Ty Coon, President of Vice
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
 
 That's all there is to it!


### PR DESCRIPTION
The GPL v1 license has had some minor updates to it, removing an out of date mailing address and a minor change to some example text.